### PR TITLE
Poll and get receipt simultaneously to improve speed when not an approval

### DIFF
--- a/.changeset/rich-rings-behave.md
+++ b/.changeset/rich-rings-behave.md
@@ -1,0 +1,6 @@
+---
+'@reservoir0x/relay-sdk': patch
+'@reservoir0x/relay-kit-ui': patch
+---
+
+Improve post transaction polling to increase speed

--- a/packages/hooks/src/hooks/useQuote.ts
+++ b/packages/hooks/src/hooks/useQuote.ts
@@ -89,11 +89,17 @@ export default function (
         throw 'Missing a quote'
       }
 
-      return client?.actions?.execute({
+      const promise = client?.actions?.execute({
         wallet,
         quote: response.data as Execute,
         onProgress
       })
+
+      promise?.then(() => {
+        response.refetch()
+      })
+
+      return promise
     },
     [response.data, wallet, client]
   )

--- a/packages/sdk/src/utils/transaction.ts
+++ b/packages/sdk/src/utils/transaction.ts
@@ -219,7 +219,11 @@ export async function sendTransactionSafely(
     }
 
     if (!receipt) {
-      receiptController.abort()
+      if (!item.check) {
+        await receiptPromise
+      } else {
+        receiptController.abort()
+      }
     }
   }
 

--- a/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
@@ -106,7 +106,12 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
               }}
             >
               <Box css={{ width: 29, height: 27 }}>
-                <FontAwesomeIcon icon={faBolt} width={29} height={27} />
+                <FontAwesomeIcon
+                  icon={faBolt}
+                  width={29}
+                  height={27}
+                  style={{ height: 27 }}
+                />
               </Box>
             </Flex>
           </Flex>

--- a/packages/ui/src/components/widget/index.tsx
+++ b/packages/ui/src/components/widget/index.tsx
@@ -508,8 +508,8 @@ const SwapWidget: FC<SwapWidgetProps> = ({
                 tradeType === 'EXACT_INPUT'
                   ? amountInputValue
                   : amountInputValue
-                  ? formatFixedLength(amountInputValue, 8)
-                  : amountInputValue
+                    ? formatFixedLength(amountInputValue, 8)
+                    : amountInputValue
               }
               setValue={(e) => {
                 setAmountInputValue(e)
@@ -689,8 +689,8 @@ const SwapWidget: FC<SwapWidgetProps> = ({
                 tradeType === 'EXACT_OUTPUT'
                   ? amountOutputValue
                   : amountOutputValue
-                  ? formatFixedLength(amountOutputValue, 8)
-                  : amountOutputValue
+                    ? formatFixedLength(amountOutputValue, 8)
+                    : amountOutputValue
               }
               setValue={(e) => {
                 setAmountOutputValue(e)


### PR DESCRIPTION
In order to improve the ux speed we poll the confirmation as well as wait for the tx receipt when executing a non-approval tx. For approvals we need to wait until the approval goes through because the check endpoint doesn't wait on the approval (there's also no check endpoint returned)