### PR TITLE
Render estimated usd value in Swap Widget before quote is made available

### DIFF
--- a/.changeset/chubby-worms-return.md
+++ b/.changeset/chubby-worms-return.md
@@ -1,0 +1,5 @@
+---
+'@reservoir0x/relay-kit-ui': patch
+---
+
+Display estimated USD value for input token before swap quote is available

--- a/.changeset/wicked-needles-taste.md
+++ b/.changeset/wicked-needles-taste.md
@@ -1,0 +1,5 @@
+---
+'@reservoir0x/relay-kit-ui': patch
+---
+
+Display estimated USD value for input token before swap quote is available

--- a/.changeset/wicked-needles-taste.md
+++ b/.changeset/wicked-needles-taste.md
@@ -1,5 +1,0 @@
----
-'@reservoir0x/relay-kit-ui': patch
----
-
-Display estimated USD value for input token before swap quote is available

--- a/packages/ui/src/components/widgets/SwapWidget/index.tsx
+++ b/packages/ui/src/components/widgets/SwapWidget/index.tsx
@@ -636,7 +636,7 @@ const SwapWidget: FC<SwapWidgetProps> = ({
                             Number(amountInputValue) > 0 ? (
                             <Box
                               css={{
-                                width: 60,
+                                width: 45,
                                 height: 12,
                                 backgroundColor: 'gray7',
                                 borderRadius: 'widget-border-radius'

--- a/packages/ui/src/components/widgets/SwapWidget/index.tsx
+++ b/packages/ui/src/components/widgets/SwapWidget/index.tsx
@@ -715,11 +715,12 @@ const SwapWidget: FC<SwapWidgetProps> = ({
                                 borderRadius: 'widget-border-radius'
                               }}
                             />
-                          ) : inputAmountUsd && inputAmountUsd > 0 ? (
+                          ) : inputAmountUsd &&
+                            inputAmountUsd > 0 &&
+                            fromTokenPriceData?.price &&
+                            fromTokenPriceData.price > 0 ? (
                             formatDollar(inputAmountUsd)
-                          ) : (
-                            formatDollar(0)
-                          )}
+                          ) : null}
                         </Text>
                         <Flex
                           align="center"
@@ -1171,11 +1172,12 @@ const SwapWidget: FC<SwapWidgetProps> = ({
                                     borderRadius: 'widget-border-radius'
                                   }}
                                 />
-                              ) : outputAmountUsd && outputAmountUsd > 0 ? (
+                              ) : outputAmountUsd &&
+                                outputAmountUsd > 0 &&
+                                toTokenPriceData?.price &&
+                                toTokenPriceData.price > 0 ? (
                                 formatDollar(outputAmountUsd)
-                              ) : (
-                                formatDollar(0)
-                              )}
+                              ) : null}
                             </Text>
                             {quote?.details?.currencyOut?.amountUsd &&
                             !isFetchingQuote &&


### PR DESCRIPTION
This PR introduces an improvement to the swap widget’s ux by displaying an estimated usd value for the input token as soon as the user enters an amount.