### PR TITLE
Render fallback token placeholder using symbol initial

### DIFF
--- a/.changeset/brown-loops-ask.md
+++ b/.changeset/brown-loops-ask.md
@@ -1,0 +1,5 @@
+---
+'@reservoir0x/relay-kit-ui': patch
+---
+
+Render fallback token placeholder using symbol initial

--- a/packages/ui/src/components/common/TokenSelector/SuggestedTokens.tsx
+++ b/packages/ui/src/components/common/TokenSelector/SuggestedTokens.tsx
@@ -94,6 +94,7 @@ export const SuggestedTokens: FC<SuggestedTokensProps> = ({
             <ChainTokenIcon
               chainId={token.chainId}
               tokenlogoURI={token.logoURI}
+              tokenSymbol={token.symbol}
             />
             <Text style="h6" ellipsify>
               {token.symbol}

--- a/packages/ui/src/components/common/TokenSelector/TokenList.tsx
+++ b/packages/ui/src/components/common/TokenSelector/TokenList.tsx
@@ -106,6 +106,7 @@ export const TokenList: FC<TokenListProps> = ({
                 <ChainTokenIcon
                   chainId={token.chainId}
                   tokenlogoURI={token.logoURI}
+                  tokenSymbol={token.symbol}
                   size="lg"
                 />
                 <Flex

--- a/packages/ui/src/components/common/TokenSelector/triggers/TokenTrigger.tsx
+++ b/packages/ui/src/components/common/TokenSelector/triggers/TokenTrigger.tsx
@@ -55,6 +55,7 @@ export const TokenTrigger: FC<TokenTriggerProps> = ({
         <ChainTokenIcon
           chainId={token.chainId}
           tokenlogoURI={token.logoURI}
+          tokenSymbol={token.symbol}
           css={{ width: 32, height: 32 }}
         />
         <Flex

--- a/packages/ui/src/components/common/TransactionModal/steps/ApprovalPlusSwapStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/ApprovalPlusSwapStep.tsx
@@ -65,6 +65,7 @@ export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
             <ChainTokenIcon
               chainId={fromToken?.chainId}
               tokenlogoURI={fromToken?.logoURI}
+              tokenSymbol={fromToken?.symbol}
               css={{ height: 32, width: 32 }}
             />
             <Text style="h6" ellipsify>
@@ -103,6 +104,7 @@ export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
             <ChainTokenIcon
               chainId={toToken?.chainId}
               tokenlogoURI={toToken?.logoURI}
+              tokenSymbol={toToken?.symbol}
               css={{ height: 32, width: 32 }}
             />
             <Text style="h6" ellipsify>
@@ -143,8 +145,8 @@ export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
           const stepTitle = isApproveStep
             ? 'Approve in wallet'
             : hasTxHash
-            ? `Swapping ${fromToken?.symbol} for ${toToken?.symbol}`
-            : 'Confirm swap in wallet'
+              ? `Swapping ${fromToken?.symbol} for ${toToken?.symbol}`
+              : 'Confirm swap in wallet'
 
           return (
             <Box key={step.id}>
@@ -158,6 +160,7 @@ export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
                     <ChainTokenIcon
                       chainId={fromToken?.chainId}
                       tokenlogoURI={fromToken?.logoURI}
+                      tokenSymbol={fromToken?.symbol}
                       css={{
                         borderRadius: 9999999,
                         flexShrink: 0,

--- a/packages/ui/src/components/common/TransactionModal/steps/SwapConfirmationStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/SwapConfirmationStep.tsx
@@ -76,6 +76,7 @@ export const SwapConfirmationStep: FC<SwapConfirmationStepProps> = ({
           <ChainTokenIcon
             chainId={fromToken?.chainId}
             tokenlogoURI={fromToken?.logoURI}
+            tokenSymbol={fromToken?.symbol}
             css={{ height: 32, width: 32 }}
           />
           <Flex direction="column" align="start" css={{ gap: '1' }}>
@@ -112,6 +113,7 @@ export const SwapConfirmationStep: FC<SwapConfirmationStepProps> = ({
           <ChainTokenIcon
             chainId={toToken?.chainId}
             tokenlogoURI={toToken?.logoURI}
+            tokenSymbol={toToken?.symbol}
             css={{ height: 32, width: 32 }}
           />
           <Flex direction="column" align="start" css={{ gap: '1' }}>

--- a/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
@@ -317,6 +317,7 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
               <ChainTokenIcon
                 chainId={_fromToken.chainId}
                 tokenlogoURI={fromTokenLogoUri}
+                tokenSymbol={_fromToken.symbol}
               />
               {isLoadingTransaction ? (
                 <Skeleton
@@ -342,6 +343,7 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
               <ChainTokenIcon
                 chainId={_toToken.chainId}
                 tokenlogoURI={toTokenLogoUri}
+                tokenSymbol={_toToken.symbol}
               />
               {isLoadingTransaction ? (
                 <Skeleton

--- a/packages/ui/src/components/primitives/ChainTokenIcon.tsx
+++ b/packages/ui/src/components/primitives/ChainTokenIcon.tsx
@@ -2,15 +2,15 @@ import { type FC } from 'react'
 import Flex from './Flex.js'
 import ChainIcon from './ChainIcon.js'
 import Box from './Box.js'
+import Text from './Text.js'
 import type { Styles } from '@reservoir0x/relay-design-system/css'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCoins } from '@fortawesome/free-solid-svg-icons'
 
 type Size = 'md' | 'lg'
 
 type ChainTokenProps = {
   chainId?: number
   tokenlogoURI?: string
+  tokenSymbol?: string
   css?: Styles
   size?: Size
 }
@@ -29,6 +29,7 @@ const SIZES = {
 export const ChainTokenIcon: FC<ChainTokenProps> = ({
   chainId,
   tokenlogoURI,
+  tokenSymbol,
   css = {},
   size = 'md'
 }) => {
@@ -48,7 +49,7 @@ export const ChainTokenIcon: FC<ChainTokenProps> = ({
             overflow: 'hidden'
           }}
         />
-      ) : (
+      ) : tokenSymbol ? (
         <Box
           css={{
             width: dimensions.token,
@@ -61,13 +62,9 @@ export const ChainTokenIcon: FC<ChainTokenProps> = ({
             justifyContent: 'center'
           }}
         >
-          <FontAwesomeIcon
-            icon={faCoins}
-            width={dimensions.token / 2}
-            height={dimensions.token / 2}
-          />
+          <Text style="h6">{tokenSymbol?.charAt(0).toUpperCase()}</Text>
         </Box>
-      )}
+      ) : null}
       <ChainIcon
         chainId={chainId}
         width={dimensions.chain}

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampConfirmingStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampConfirmingStep.tsx
@@ -71,9 +71,10 @@ export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
           <ChainTokenIcon
             chainId={fromToken?.chainId}
             tokenlogoURI={fromToken?.logoURI}
+            tokenSymbol={fromToken?.symbol}
           />
           <Text style="subtitle1">
-            You’ll purchase {fromToken?.symbol} ({fromChain?.displayName}) via
+            You'll purchase {fromToken?.symbol} ({fromChain?.displayName}) via
             your card
           </Text>
         </Flex>
@@ -90,6 +91,7 @@ export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
           <ChainTokenIcon
             chainId={toToken?.chainId}
             tokenlogoURI={toToken?.logoURI}
+            tokenSymbol={toToken?.symbol}
           />
           <Text style="subtitle1">
             Relay converts to {toToken?.symbol} ({toChain?.displayName})

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampMoonPayStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampMoonPayStep.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, Suspense, useCallback, useEffect, type FC } from 'react'
+import { lazy, memo, Suspense, useEffect, type FC } from 'react'
 import {
   Box,
   ChainTokenIcon,
@@ -87,7 +87,7 @@ export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
   onError
 }) => {
   const moonPayExternalId = !isPassthrough
-    ? quoteRequestId ?? undefined
+    ? (quoteRequestId ?? undefined)
     : passthroughExternalId
   useEffect(() => {
     if (window) {
@@ -217,6 +217,7 @@ export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
             <ChainTokenIcon
               chainId={toToken?.chainId}
               tokenlogoURI={toToken?.logoURI}
+              tokenSymbol={toToken?.symbol}
               css={{
                 width: 32,
                 height: 32,
@@ -229,6 +230,7 @@ export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
             <ChainTokenIcon
               chainId={fromToken?.chainId}
               tokenlogoURI={fromToken?.logoURI}
+              tokenSymbol={fromToken?.symbol}
               css={{
                 width: 32,
                 height: 32,

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingPassthroughStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingPassthroughStep.tsx
@@ -9,7 +9,6 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import type { Token } from '../../../../../types/index.js'
-import type { RelayChain } from '@reservoir0x/relay-sdk'
 import { LoadingSpinner } from '../../../../common/LoadingSpinner.js'
 import MoonPayLogo from '../../../../../img/MoonPayLogo.js'
 
@@ -48,6 +47,7 @@ export const OnrampProcessingPassthroughStep: FC<
         <ChainTokenIcon
           chainId={toToken?.chainId}
           tokenlogoURI={toToken?.logoURI}
+          tokenSymbol={toToken?.symbol}
           css={{
             width: 32,
             height: 32

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingStepUI.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingStepUI.tsx
@@ -93,6 +93,7 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
           <ChainTokenIcon
             chainId={fromToken?.chainId}
             tokenlogoURI={fromToken?.logoURI}
+            tokenSymbol={fromToken?.symbol}
             css={{
               width: 32,
               height: 32,

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampSuccessStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampSuccessStep.tsx
@@ -86,6 +86,7 @@ export const OnrampSuccessStep: FC<OnrampSuccessStepProps> = ({
           <ChainTokenIcon
             chainId={toToken.chainId}
             tokenlogoURI={toToken.logoURI}
+            tokenSymbol={toToken.symbol}
             css={{ height: 32, width: 32 }}
           />
           {isLoadingTransaction ? (


### PR DESCRIPTION
This PR introduces a fallback mechanism that displays the first letter of a token’s symbol as a placeholder image when the token image is unavailable, improving visual distinction and usability.