### PR TITLE
chore: fix link to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When you're ready to contribute, submit a pull request with your changes. Our te
 ---
 
 <p align="center">
-  <a href="https://reservoir.tools/">Home</a> • <a href="https://docs.relay.link">Documentation</a> • <a href="https://github.com/reservoir-tools/relay-sdk">GitHub</a>
+  <a href="https://reservoir.tools/">Home</a> • <a href="https://docs.relay.link">Documentation</a> • <a href="https://github.com/reservoirprotocol/relay-kit">GitHub</a>
 </p>
 
 <p align="center"> Made with <span style="color: #e25555;">&hearts;</span> by the team @ <a href="https://reservoir.tools/">Reservoir</a></p>


### PR DESCRIPTION
previous is not working any more