### PR TITLE
add disableCapabilitiesCheck option to skip wallet.getCapabilities pr…

### DIFF
--- a/.changeset/spotty-chairs-pull.md
+++ b/.changeset/spotty-chairs-pull.md
@@ -1,0 +1,5 @@
+---
+'@relayprotocol/relay-sdk': patch
+---
+
+add disableCapabilitiesCheck option to skip wallet.getCapabilities

--- a/packages/sdk/src/actions/claimAppFees.ts
+++ b/packages/sdk/src/actions/claimAppFees.ts
@@ -8,7 +8,10 @@ import {
   getApiKeyHeader
 } from '../utils/index.js'
 import { type WalletClient } from 'viem'
-import { isViemWalletClient } from '../utils/viemWallet.js'
+import {
+  isViemWalletClient,
+  type AdaptViemWalletOptions
+} from '../utils/viemWallet.js'
 import type { paths } from '../types/index.js'
 import type { AxiosRequestConfig } from 'axios'
 
@@ -26,7 +29,7 @@ export type ClaimAppFeesParameters = {
   recipient?: string
   amount?: string
   onProgress?: (data: any) => any
-}
+} & AdaptViemWalletOptions
 
 /**
  * Claim app fees for a wallet and execute the returned steps
@@ -38,8 +41,15 @@ export async function claimAppFees(
   data: Execute
   abortController: AbortController
 }> {
-  const { wallet, chainId, currency, recipient, amount, onProgress } =
-    parameters
+  const {
+    wallet,
+    chainId,
+    currency,
+    recipient,
+    amount,
+    onProgress,
+    disableCapabilitiesCheck
+  } = parameters
   const client = getClient()
 
   if (!client.baseApiUrl || !client.baseApiUrl.length) {
@@ -49,7 +59,7 @@ export async function claimAppFees(
   let adaptedWallet: AdaptedWallet | undefined
   if (wallet) {
     adaptedWallet = isViemWalletClient(wallet)
-      ? adaptViemWallet(wallet as WalletClient)
+      ? adaptViemWallet(wallet as WalletClient, { disableCapabilitiesCheck })
       : wallet
   }
 

--- a/packages/sdk/src/actions/execute.ts
+++ b/packages/sdk/src/actions/execute.ts
@@ -7,7 +7,10 @@ import {
   safeStructuredClone
 } from '../utils/index.js'
 import { type WalletClient } from 'viem'
-import { isViemWalletClient } from '../utils/viemWallet.js'
+import {
+  isViemWalletClient,
+  type AdaptViemWalletOptions
+} from '../utils/viemWallet.js'
 import { isDeadAddress } from '../constants/address.js'
 
 export type ExecuteActionParameters = {
@@ -15,7 +18,7 @@ export type ExecuteActionParameters = {
   wallet: AdaptedWallet | WalletClient
   depositGasLimit?: string
   onProgress?: (data: ProgressData) => any
-}
+} & AdaptViemWalletOptions
 
 /**
  * Execute crosschain using Relay
@@ -31,7 +34,8 @@ export function execute(data: ExecuteActionParameters): Promise<{
 }> & {
   abortController: AbortController
 } {
-  const { quote, wallet, depositGasLimit, onProgress } = data
+  const { quote, wallet, depositGasLimit, onProgress, disableCapabilitiesCheck } =
+    data
   const client = getClient()
 
   if (!client.baseApiUrl || !client.baseApiUrl.length) {
@@ -41,7 +45,7 @@ export function execute(data: ExecuteActionParameters): Promise<{
   let adaptedWallet: AdaptedWallet | undefined
   if (wallet) {
     adaptedWallet = isViemWalletClient(wallet)
-      ? adaptViemWallet(wallet as WalletClient)
+      ? adaptViemWallet(wallet as WalletClient, { disableCapabilitiesCheck })
       : wallet
   }
 

--- a/packages/sdk/src/actions/getQuote.ts
+++ b/packages/sdk/src/actions/getQuote.ts
@@ -9,7 +9,10 @@ import {
   getApiKeyHeader,
   type SimulateContractRequest
 } from '../utils/index.js'
-import { isViemWalletClient } from '../utils/viemWallet.js'
+import {
+  isViemWalletClient,
+  type AdaptViemWalletOptions
+} from '../utils/viemWallet.js'
 import { getClient, RelayClient } from '../client.js'
 import type { AdaptedWallet, Execute, paths } from '../types/index.js'
 import { getDeadAddress } from '../constants/address.js'
@@ -39,7 +42,7 @@ export type GetQuoteParameters = {
   recipient?: string
   options?: Omit<Partial<QuoteBodyOptions>, 'source' | 'txs' | 'tradeType'>
   txs?: (NonNullable<QuoteBody['txs']>[0] | SimulateContractRequest)[]
-}
+} & AdaptViemWalletOptions
 
 const getDefaultQuoteParameters = async (
   client: RelayClient,
@@ -91,7 +94,8 @@ export async function getQuote(
     recipient,
     options,
     txs,
-    user
+    user,
+    disableCapabilitiesCheck
   } = parameters
 
   const client = getClient()
@@ -103,7 +107,7 @@ export async function getQuote(
   let adaptedWallet: AdaptedWallet | undefined
   if (wallet) {
     adaptedWallet = isViemWalletClient(wallet)
-      ? adaptViemWallet(wallet as WalletClient)
+      ? adaptViemWallet(wallet as WalletClient, { disableCapabilitiesCheck })
       : wallet
   }
 

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -5,7 +5,11 @@ export { request, APIError, isAPIError } from './request.js'
 export { log, LogLevel } from './logger.js'
 export { axios } from './axios.js'
 export { default as prepareCallTransaction } from './prepareCallTransaction.js'
-export { adaptViemWallet, isViemWalletClient } from './viemWallet.js'
+export {
+  adaptViemWallet,
+  isViemWalletClient,
+  type AdaptViemWalletOptions
+} from './viemWallet.js'
 export { convertViemChainToRelayChain, type RelayAPIChain } from './chain.js'
 export { getCurrentStepData } from './getCurrentStepData.js'
 export {

--- a/packages/sdk/src/utils/viemWallet.test.ts
+++ b/packages/sdk/src/utils/viemWallet.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { adaptViemWallet } from './viemWallet'
+
+const buildWallet = (overrides: Record<string, any> = {}) =>
+  ({
+    account: { address: '0x0000000000000000000000000000000000000001' },
+    transport: { request: vi.fn() },
+    getCapabilities: vi
+      .fn()
+      .mockResolvedValue({ atomicBatch: { supported: true } }),
+    ...overrides
+  }) as any
+
+describe('adaptViemWallet disableCapabilitiesCheck', () => {
+  it('supportsAtomicBatch calls wallet.getCapabilities by default', async () => {
+    const wallet = buildWallet()
+    const adapted = adaptViemWallet(wallet)
+
+    const result = await adapted.supportsAtomicBatch!(1)
+
+    expect(result).toBe(true)
+    expect(wallet.getCapabilities).toHaveBeenCalledWith({
+      account: wallet.account,
+      chainId: 1
+    })
+  })
+
+  it('supportsAtomicBatch returns false and skips getCapabilities when disabled', async () => {
+    const wallet = buildWallet()
+    const adapted = adaptViemWallet(wallet, { disableCapabilitiesCheck: true })
+
+    const result = await adapted.supportsAtomicBatch!(1)
+
+    expect(result).toBe(false)
+    expect(wallet.getCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('does not await a hanging getCapabilities when disabled', async () => {
+    // Simulates the Coinbase-Wallet-via-Dynamic case: getCapabilities
+    // never resolves. With the flag, we must not call it at all.
+    const hangingGetCapabilities = vi
+      .fn()
+      .mockImplementation(() => new Promise<never>(() => {}))
+    const wallet = buildWallet({ getCapabilities: hangingGetCapabilities })
+    const adapted = adaptViemWallet(wallet, { disableCapabilitiesCheck: true })
+
+    await expect(adapted.supportsAtomicBatch!(1)).resolves.toBe(false)
+    expect(hangingGetCapabilities).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sdk/src/utils/viemWallet.ts
+++ b/packages/sdk/src/utils/viemWallet.ts
@@ -34,7 +34,21 @@ export function isViemWalletClient(
   )
 }
 
-export const adaptViemWallet = (wallet: WalletClient): AdaptedWallet => {
+export type AdaptViemWalletOptions = {
+  /**
+   * Skip `wallet.getCapabilities` calls used for EIP-5792 atomic-batch
+   * detection and smart-wallet detection. Set this for wallets with a
+   * broken `getCapabilities` implementation that hangs or never resolves.
+   * When true, execution falls back to sequential transactions.
+   */
+  disableCapabilitiesCheck?: boolean
+}
+
+export const adaptViemWallet = (
+  wallet: WalletClient,
+  options: AdaptViemWalletOptions = {}
+): AdaptedWallet => {
+  const { disableCapabilitiesCheck } = options
   return {
     vmType: 'evm',
     getChainId: async () => {
@@ -206,6 +220,7 @@ export const adaptViemWallet = (wallet: WalletClient): AdaptedWallet => {
       }
     },
     supportsAtomicBatch: async (chainId) => {
+      if (disableCapabilitiesCheck) return false
       if (!wallet.account) return false
       try {
         const capabilities = await wallet.getCapabilities({
@@ -284,6 +299,7 @@ export const adaptViemWallet = (wallet: WalletClient): AdaptedWallet => {
 
         // Always fetch capabilities fresh (wallet-specific, not cacheable)
         const getSmartWalletCapabilities = async () => {
+          if (disableCapabilitiesCheck) return false
           let _hasSmartWalletCapabilities = false
           try {
             const capabilities = await wallet.getCapabilities({


### PR DESCRIPTION
Originally opened: #981 

Some wallets ship broken getCapabilities implementations that hang and stall checkout. Expose an opt-in flag on adaptViemWallet and on the execute / getQuote / claimAppFees actions so integrators can bypass both the EIP-5792 atomic-batch probe and the smart-wallet detection inside isEOA when they know a given wallet is bad.