### PR TITLE
fix(tron): handle native TRX deposit value and balance

### DIFF
--- a/.changeset/tron-native-trx-fix.md
+++ b/.changeset/tron-native-trx-fix.md
@@ -1,0 +1,7 @@
+---
+'@relayprotocol/relay-sdk': patch
+'@relayprotocol/relay-tron-wallet-adapter': patch
+'@relayprotocol/relay-kit-ui': patch
+---
+
+Fix native TRX handling on Tron: forward call_value on the deposit transaction (was sending 0 TRX) and read native balance via getaccount instead of a balanceOf contract call.

--- a/.changeset/tron-native-trx-fix.md
+++ b/.changeset/tron-native-trx-fix.md
@@ -4,4 +4,4 @@
 '@relayprotocol/relay-kit-ui': patch
 ---
 
-Fix native TRX handling on Tron: forward call_value on the deposit transaction (was sending 0 TRX) and read native balance via getaccount instead of a balanceOf contract call.
+Fix native TRX handling on Tron: forward call_value on the deposit transaction (was sending 0 TRX) and fix the native-TRX sentinel address (the wrong sentinel made native TRX fall through to a failing balanceOf call).

--- a/packages/relay-tron-wallet-adapter/src/adapter.ts
+++ b/packages/relay-tron-wallet-adapter/src/adapter.ts
@@ -41,6 +41,8 @@ export const adaptTronWallet = (
         owner_address: stepItem.data.parameter?.owner_address,
         contract_address: stepItem.data.parameter?.contract_address,
         data: strip0x(stepItem.data.parameter?.data!),
+        // Native TRX amount rides in call_value, not calldata
+        call_value: stepItem.data.parameter?.call_value ?? 0,
         visible: false,
         fee_limit: 30_000_000
       }

--- a/packages/sdk/src/types/TransactionStepItem.ts
+++ b/packages/sdk/src/types/TransactionStepItem.ts
@@ -40,6 +40,8 @@ export type TransactionStepItem = Pick<
       owner_address: string
       contract_address: string
       data: string
+      // Native TRX amount (msg.value) for payable calls
+      call_value?: number
     }
     // Lighter (LVM)
     action?: {

--- a/packages/ui/src/hooks/useTronBalance.ts
+++ b/packages/ui/src/hooks/useTronBalance.ts
@@ -137,7 +137,8 @@ export default (
   queryOptions?: Partial<QueryOptions>
 ) => {
   const rpcUrl = 'https://api.trongrid.io'
-  const trxAddress = 'TXuo7BWT6hDdotW8LPPeiShe1KHUFzB6hJ'
+  // Native TRX sentinel returned by the Relay API (decodes to the zero address)
+  const trxAddress = 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb'
 
   const queryKey = ['useTronBalance', address, currency]
 
@@ -163,7 +164,7 @@ export default (
             throw new Error(data.error.message)
           }
 
-          const result = data.result as TronAccountResponse
+          const result = data as Partial<TronAccountResponse>
 
           return {
             balance: BigInt(result.balance ?? 0)
@@ -192,7 +193,21 @@ export default (
             throw new Error(data.error.message)
           }
 
+          // Trigger failures arrive on data.result, not data.error — surface
+          // them instead of returning a 0 balance (message is plaintext here)
+          if (data.result?.result === false || data.result?.code) {
+            throw new Error(
+              data.result?.message ??
+                data.result?.code ??
+                'triggerconstantcontract failed'
+            )
+          }
+
           const hex = data?.constant_result?.[0] as string | undefined
+
+          if (!hex) {
+            throw new Error('Empty constant_result from triggerconstantcontract')
+          }
 
           return {
             balance: BigInt('0x' + hex)


### PR DESCRIPTION
## Summary

Native TRX (zero-address sentinel) was treated like a TRC-20 token on both the write and read paths.

**Write path** (`relay-tron-wallet-adapter`): the `triggersmartcontract` body omitted `call_value`, so `depositNative` ran with **0 TRX** attached — deposit mined `SUCCESS` but the swap was never funded. Now forwards `parameter.call_value`.

**SDK types**: added `call_value?: number` to the Tron `TransactionStepItem` parameter.

**Read path** (`useTronBalance`):
- Fixed the native sentinel to `T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb` (decodes to the zero address). The old value pointed at a real contract, so native TRX wrongly fell through to a `balanceOf` call.
- Read balance from the top-level `getaccount` response (it was reading `data.result.balance`, which is always empty → 0).
- Throw on `triggerconstantcontract` failures instead of silently returning a 0 balance.

Verified the sentinel against the prod currency row + `/chains` API, and `call_value` against the solver backend source.
