### PR TITLE
refactor(sdk): convert convertViemChainToRelayChain to function declaration

### DIFF
--- a/.changeset/convert-viem-chain-fn-declaration.md
+++ b/.changeset/convert-viem-chain-fn-declaration.md
@@ -1,0 +1,5 @@
+---
+'@relayprotocol/relay-sdk': patch
+---
+
+Convert `convertViemChainToRelayChain` from an arrow function to a function declaration (no behavior change).

--- a/packages/sdk/src/utils/chain.ts
+++ b/packages/sdk/src/utils/chain.ts
@@ -8,9 +8,9 @@ export type RelayAPIChain = Required<
   >['0']
 >
 
-export const convertViemChainToRelayChain = (
+export function convertViemChainToRelayChain(
   chain: Chain
-): RelayChain & Required<Pick<RelayChain, 'viemChain'>> => {
+): RelayChain & Required<Pick<RelayChain, 'viemChain'>> {
   return {
     id: chain.id,
     name: chain.name.replace(' ', '-'),


### PR DESCRIPTION
Issue:  relay-sdk has a circular import: client.js → utils/index.js → executeSteps/index.js (+ transaction.js, viemWallet.js) → back to client.js. 

And client.js calls convertViemChainToRelayChain at module-eval top level:

```js
const _backupMainnetChain = utils.convertViemChainToRelayChain(mainnet);  // line 8
```

This will break some bunlders like vite.

This PR changes it to use function declaration instead to create a forward reference.