### PR TITLE
refactor: convert exported arrow consts to function declarations

### DIFF
--- a/.changeset/convert-viem-chain-fn-declaration.md
+++ b/.changeset/convert-viem-chain-fn-declaration.md
@@ -1,0 +1,5 @@
+---
+'@relayprotocol/relay-sdk': patch
+---
+
+Convert `convertViemChainToRelayChain` from an arrow function to a function declaration (no behavior change).

--- a/.changeset/convert-viem-chain-fn-declaration.md
+++ b/.changeset/convert-viem-chain-fn-declaration.md
@@ -1,5 +1,12 @@
 ---
 '@relayprotocol/relay-sdk': patch
+'@relayprotocol/relay-kit-ui': patch
+'@relayprotocol/relay-kit-hooks': patch
+'@relayprotocol/relay-bitcoin-wallet-adapter': patch
+'@relayprotocol/relay-ethers-wallet-adapter': patch
+'@relayprotocol/relay-lighter-wallet-adapter': patch
+'@relayprotocol/relay-svm-wallet-adapter': patch
+'@relayprotocol/relay-tron-wallet-adapter': patch
 ---
 
-Convert `convertViemChainToRelayChain` from an arrow function to a function declaration (no behavior change).
+Convert exported arrow-function consts to function declarations across all packages (no behavior change).

--- a/packages/hooks/src/fetcher.ts
+++ b/packages/hooks/src/fetcher.ts
@@ -13,11 +13,11 @@ const fetcher = async (url: string, headers?: HeadersInit) => {
 
 export default fetcher
 
-export const axiosPostFetcher = async (
+export async function axiosPostFetcher(
   url: string,
   params: any,
   config?: AxiosRequestConfig
-) => {
+) {
   const { data } = await axios.post(url, params, config)
   return data
 }

--- a/packages/relay-bitcoin-wallet-adapter/src/adapter.ts
+++ b/packages/relay-bitcoin-wallet-adapter/src/adapter.ts
@@ -15,7 +15,7 @@ type DynamicSignPsbtParams = {
   }>
 }
 
-export const adaptBitcoinWallet = (
+export function adaptBitcoinWallet(
   walletAddress: string,
   signPsbt: (
     address: string,
@@ -23,7 +23,7 @@ export const adaptBitcoinWallet = (
     dynamicParams: DynamicSignPsbtParams
   ) => Promise<string>,
   publicKey?: string
-): AdaptedWallet => {
+): AdaptedWallet {
   return {
     vmType: 'bvm',
     getChainId: async () => {

--- a/packages/relay-ethers-wallet-adapter/src/adapter.ts
+++ b/packages/relay-ethers-wallet-adapter/src/adapter.ts
@@ -16,10 +16,10 @@ import {
   type HttpTransport
 } from 'viem'
 
-export const adaptEthersSigner = (
+export function adaptEthersSigner(
   signer: Signer,
   transport?: CustomTransport | HttpTransport
-): AdaptedWallet => {
+): AdaptedWallet {
   return {
     vmType: 'evm',
     transport,

--- a/packages/relay-lighter-wallet-adapter/src/adapter.ts
+++ b/packages/relay-lighter-wallet-adapter/src/adapter.ts
@@ -327,9 +327,9 @@ export type AdaptLighterWalletOptions =
  * dependency on `@relay-protocol/lighter-ts-sdk`.
  *
  */
-export const adaptLighterWallet = (
+export function adaptLighterWallet(
   options: AdaptLighterWalletOptions
-): AdaptedWallet => {
+): AdaptedWallet {
   const {
     l1Address,
     signL1Message,

--- a/packages/relay-svm-wallet-adapter/src/adapter.ts
+++ b/packages/relay-svm-wallet-adapter/src/adapter.ts
@@ -38,7 +38,7 @@ const assertBase58TransactionSignature = (
  * @param payerKey - Optional public key of the account that will pay for transaction fees (defaults to walletAddress)
  * @returns An AdaptedWallet object that conforms to the Relay SDK interface
  */
-export const adaptSolanaWallet = (
+export function adaptSolanaWallet(
   walletAddress: string,
   chainId: number,
   connection: Connection,
@@ -51,7 +51,7 @@ export const adaptSolanaWallet = (
     signature: TransactionSignature
   }>,
   payerKey?: string
-): AdaptedWallet => {
+): AdaptedWallet {
   let _chainId = chainId
   const getChainId = async () => {
     return _chainId

--- a/packages/relay-tron-wallet-adapter/src/adapter.ts
+++ b/packages/relay-tron-wallet-adapter/src/adapter.ts
@@ -12,10 +12,10 @@ import type { TriggerSmartContractResponse } from './types.js'
  * @param tronWeb - The TronWeb instance for interacting with the Tron network
  * @returns An AdaptedWallet object that conforms to the Relay SDK interface
  */
-export const adaptTronWallet = (
+export function adaptTronWallet(
   walletAddress: string,
   tronWeb: TronWeb
-): AdaptedWallet => {
+): AdaptedWallet {
   const getChainId = async () => {
     return 728126428
   }

--- a/packages/sdk/src/chain-utils/configureViemChain.ts
+++ b/packages/sdk/src/chain-utils/configureViemChain.ts
@@ -17,9 +17,9 @@ const viemChainMap = Object.values(viemChains).reduce(
   {} as Record<number, Chain>
 )
 
-export const configureViemChain = (
+export function configureViemChain(
   chain: RelayAPIChain
-): RelayChain & Required<Pick<RelayChain, 'viemChain'>> => {
+): RelayChain & Required<Pick<RelayChain, 'viemChain'>> {
   let viemChain: Chain
   const overriddenChains = [999, 1337]
   const staticChain = overriddenChains.includes(chain.id)

--- a/packages/sdk/src/chain-utils/fetchChainConfigs.ts
+++ b/packages/sdk/src/chain-utils/fetchChainConfigs.ts
@@ -3,11 +3,11 @@ import type { RelayChain } from '../types/index.js'
 import { axios } from '../utils/axios.js'
 import { isRelayApiUrl } from '../utils/apiKey.js'
 
-export const fetchChainConfigs = async (
+export async function fetchChainConfigs(
   baseApiUrl: string,
   referrer?: string,
   apiKey?: string
-): Promise<RelayChain[]> => {
+): Promise<RelayChain[]> {
   let queryString = ''
   if (referrer) {
     const queryParams = new URLSearchParams()
@@ -28,4 +28,3 @@ export const fetchChainConfigs = async (
   }
   throw 'No Chain Data'
 }
-

--- a/packages/sdk/src/constants/address.ts
+++ b/packages/sdk/src/constants/address.ts
@@ -15,7 +15,7 @@ export const tonDeadAddress =
 const eclipseId = 9286185
 const zeroChainId = 543210
 
-export const getDeadAddress = (vmType?: ChainVM, chainId?: number) => {
+export function getDeadAddress(vmType?: ChainVM, chainId?: number) {
   if (vmType === 'svm') {
     return chainId === eclipseId ? eclipseDeadAddress : solDeadAddress
   } else if (vmType === 'bvm') {
@@ -31,7 +31,7 @@ export const getDeadAddress = (vmType?: ChainVM, chainId?: number) => {
   }
 }
 
-export const isDeadAddress = (address?: string) => {
+export function isDeadAddress(address?: string) {
   if (!address) {
     return false
   }

--- a/packages/sdk/src/utils/chain.ts
+++ b/packages/sdk/src/utils/chain.ts
@@ -8,9 +8,9 @@ export type RelayAPIChain = Required<
   >['0']
 >
 
-export const convertViemChainToRelayChain = (
+export function convertViemChainToRelayChain(
   chain: Chain
-): RelayChain & Required<Pick<RelayChain, 'viemChain'>> => {
+): RelayChain & Required<Pick<RelayChain, 'viemChain'>> {
   return {
     id: chain.id,
     name: chain.name.replace(' ', '-'),

--- a/packages/sdk/src/utils/getCurrentStepData.ts
+++ b/packages/sdk/src/utils/getCurrentStepData.ts
@@ -1,6 +1,6 @@
 import type { Execute } from '../types/index.js'
 
-export const getCurrentStepData = (steps: Execute['steps']) => {
+export function getCurrentStepData(steps: Execute['steps']) {
   let currentStep: NonNullable<Execute['steps']>['0'] | null = null
   let currentStepItem: NonNullable<Execute['steps'][0]['items']>[0] | undefined
   let txHashes: { txHash: string; chainId: number }[] = []

--- a/packages/sdk/src/utils/getTenderlyDetails.ts
+++ b/packages/sdk/src/utils/getTenderlyDetails.ts
@@ -5,10 +5,10 @@ export type TenderlyErrorInfo = {
   error?: string
 }
 
-export const getTenderlyDetails = (
+export function getTenderlyDetails(
   chainId: number,
   txHash: string
-): Promise<TenderlyErrorInfo | null> => {
+): Promise<TenderlyErrorInfo | null> {
   return new Promise((resolve) => {
     axios
       .get(

--- a/packages/sdk/src/utils/logger.ts
+++ b/packages/sdk/src/utils/logger.ts
@@ -6,7 +6,7 @@ export enum LogLevel {
   None = 0
 }
 
-export const log = (params: any[], level: LogLevel, currentLevel: LogLevel) => {
+export function log(params: any[], level: LogLevel, currentLevel: LogLevel) {
   if (currentLevel >= level) {
     const data = params.reduce((params, param, i) => {
       if ((i + 1) % 2) {

--- a/packages/sdk/src/utils/viemWallet.ts
+++ b/packages/sdk/src/utils/viemWallet.ts
@@ -44,10 +44,10 @@ export type AdaptViemWalletOptions = {
   disableCapabilitiesCheck?: boolean
 }
 
-export const adaptViemWallet = (
+export function adaptViemWallet(
   wallet: WalletClient,
   options: AdaptViemWalletOptions = {}
-): AdaptedWallet => {
+): AdaptedWallet {
   const { disableCapabilitiesCheck } = options
   return {
     vmType: 'evm',

--- a/packages/sdk/src/utils/websocket.ts
+++ b/packages/sdk/src/utils/websocket.ts
@@ -28,7 +28,7 @@ export interface TrackRequestStatusOptions<E extends WebSocketEvent> {
 }
 
 // @TODO: remove once requestId gets added to top level of quote response
-export const extractDepositRequestId = (steps?: Execute['steps'] | null) => {
+export function extractDepositRequestId(steps?: Execute['steps'] | null) {
   if (!steps?.length) return null
 
   // Find the first step that has a requestId

--- a/packages/ui/src/components/common/BalanceDisplay.tsx
+++ b/packages/ui/src/components/common/BalanceDisplay.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { Flex, Skeleton, Text } from '../primitives/index.js'
 import { formatBN } from '../../utils/numbers.js'
 
@@ -15,7 +14,7 @@ type BalanceDisplayProps = {
   size?: 'sm' | 'md'
 }
 
-export const BalanceDisplay: FC<BalanceDisplayProps> = ({
+export function BalanceDisplay({
   balance,
   decimals,
   symbol,
@@ -26,7 +25,7 @@ export const BalanceDisplay: FC<BalanceDisplayProps> = ({
   pending,
   hideBalanceLabel = false,
   size = 'sm'
-}) => {
+}: BalanceDisplayProps) {
   const compactBalance = Boolean(
     balance && decimals && balance.toString().length - decimals > 4
   )

--- a/packages/ui/src/components/common/CopyToClipBoard.tsx
+++ b/packages/ui/src/components/common/CopyToClipBoard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react'
+import { useState } from 'react'
 import { Button, Text } from '../primitives/index.js'
 import Tooltip from '../primitives/Tooltip.js'
 import { useCopyToClipboard } from 'usehooks-ts'
@@ -10,7 +10,7 @@ type CopyToClipBoardProps = {
   text: string
 }
 
-export const CopyToClipBoard: FC<CopyToClipBoardProps> = ({ text }) => {
+export function CopyToClipBoard({ text }: CopyToClipBoardProps) {
   const [value, copy] = useCopyToClipboard()
   const [isCopied, setIsCopied] = useState(false)
   const [open, setOpen] = useState(false)

--- a/packages/ui/src/components/common/CustomAddressModal.tsx
+++ b/packages/ui/src/components/common/CustomAddressModal.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useEffect, useMemo, useContext } from 'react'
+import { useState, useEffect, useMemo, useContext } from 'react'
 import { Text, Flex, Button, Input, Pill } from '../primitives/index.js'
 import { Modal } from '../common/Modal.js'
 import { type Address, isAddress } from 'viem'
@@ -46,7 +46,7 @@ type Props = {
   onClear: () => void
 }
 
-export const CustomAddressModal: FC<Props> = ({
+export function CustomAddressModal({
   open,
   toAddress,
   toChain,
@@ -58,7 +58,7 @@ export const CustomAddressModal: FC<Props> = ({
   onOpenChange,
   onConfirmed,
   onClear
-}) => {
+}: Props) {
   const haptic = useHapticEvent()
   const connectedAddress = useWalletAddress(wallet, linkedWallets)
   const [address, setAddress] = useState('')
@@ -182,9 +182,7 @@ export const CustomAddressModal: FC<Props> = ({
       >
         <Text style="h6">To Address</Text>
         <Flex direction="column" className="relay:gap-2 relay:relative">
-          <Flex
-            className="relay:relative relay:w-full"
-          >
+          <Flex className="relay:relative relay:w-full">
             <Input
               type="text"
               inputMode="text"

--- a/packages/ui/src/components/common/LoadingSpinner.tsx
+++ b/packages/ui/src/components/common/LoadingSpinner.tsx
@@ -17,7 +17,7 @@ const SpinnerSVG: FC<SVGProps<SVGSVGElement>> = (props) => {
   )
 }
 
-export const LoadingSpinner: FC<{ className?: string }> = ({ className }) => {
+export function LoadingSpinner({ className }: { className?: string }) {
   const providerOptionsContext = useContext(ProviderOptionsContext)
   if (providerOptionsContext.loader) {
     return (

--- a/packages/ui/src/components/common/MultiWalletDropdown.tsx
+++ b/packages/ui/src/components/common/MultiWalletDropdown.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState, type FC } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Dropdown, DropdownMenuItem } from '../primitives/Dropdown.js'
 import { Box, Button, Flex, Text } from '../primitives/index.js'
 import type { LinkedWallet } from '../../types/index.js'
@@ -32,7 +32,7 @@ type MultiWalletDropdownProps = {
   disableWalletFiltering?: boolean
 }
 
-export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
+export function MultiWalletDropdown({
   context,
   wallets,
   selectedWalletAddress,
@@ -44,7 +44,7 @@ export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
   onLinkNewWallet,
   setAddressModalOpen,
   disableWalletFiltering = false
-}) => {
+}: MultiWalletDropdownProps) {
   const [open, setOpen] = useState(false)
   const providerOptionsContext = useContext(ProviderOptionsContext)
   const connectorKeyOverrides = providerOptionsContext.vmConnectorKeyOverrides
@@ -157,7 +157,10 @@ export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
           className="relay:gap-2 relay:!px-2 relay:py-1 relay:cursor-pointer relay:flex relay:content-center"
           data-testid={testId}
         >
-          <Flex align="center" className="relay:gap-1 relay:shrink relay:min-w-0">
+          <Flex
+            align="center"
+            className="relay:gap-1 relay:shrink relay:min-w-0"
+          >
             {isSupportedSelectedWallet && selectedWallet?.walletLogoUrl ? (
               <img
                 src={selectedWallet.walletLogoUrl}
@@ -172,11 +175,14 @@ export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
               style="subtitle2"
               className="relay:whitespace-nowrap relay:overflow-hidden relay:text-ellipsis"
             >
-              <span style={{
-                color: !selectedWallet && selectedWalletAddress
-                  ? 'var(--relay-colors-amber11)'
-                  : 'var(--relay-colors-primary11)'
-              }}>
+              <span
+                style={{
+                  color:
+                    !selectedWallet && selectedWalletAddress
+                      ? 'var(--relay-colors-amber11)'
+                      : 'var(--relay-colors-primary11)'
+                }}
+              >
                 {isSupportedSelectedWallet &&
                 selectedWalletAddress &&
                 selectedWalletAddress != ''
@@ -191,9 +197,10 @@ export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
             <div
               className="relay:shrink-0"
               style={{
-                color: !selectedWallet && selectedWalletAddress
-                  ? 'var(--relay-colors-amber11)'
-                  : 'var(--relay-colors-primary11)'
+                color:
+                  !selectedWallet && selectedWalletAddress
+                    ? 'var(--relay-colors-amber11)'
+                    : 'var(--relay-colors-primary11)'
               }}
             >
               <FontAwesomeIcon icon={faChevronDown} width={14} height={14} />
@@ -208,7 +215,10 @@ export const MultiWalletDropdown: FC<MultiWalletDropdownProps> = ({
         className: 'relay:max-w-[248px] relay:p-0'
       }}
     >
-      <Flex direction="column" className="relay:rounded-[12px] relay:p-1 relay:gap-1">
+      <Flex
+        direction="column"
+        className="relay:rounded-[12px] relay:p-1 relay:gap-1"
+      >
         {filteredWallets.map((wallet, idx) => {
           return (
             <DropdownMenuItem

--- a/packages/ui/src/components/common/PercentageButtons.tsx
+++ b/packages/ui/src/components/common/PercentageButtons.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import { Button, Flex } from '../primitives/index.js'
 import type { ChainVM, RelayChain } from '@relayprotocol/relay-sdk'
 import type { PublicClient } from 'viem'
@@ -25,7 +24,7 @@ type PercentageButtonsProps = {
   buttonClassName?: string
 }
 
-export const PercentageButtons: FC<PercentageButtonsProps> = ({
+export function PercentageButtons({
   balance,
   onPercentageClick,
   getFeeBufferAmount,
@@ -35,7 +34,7 @@ export const PercentageButtons: FC<PercentageButtonsProps> = ({
   variant = 'desktop',
   percentages = [20, 50],
   buttonClassName: customButtonClassName
-}) => {
+}: PercentageButtonsProps) {
   const getExecutionBuffer = (amount: bigint) => {
     if (amount <= 0n) return 0n
 

--- a/packages/ui/src/components/common/SlippageToleranceConfig.tsx
+++ b/packages/ui/src/components/common/SlippageToleranceConfig.tsx
@@ -112,9 +112,7 @@ const SlippageTabs: FC<SlippageTabsProps> = ({
         className="relay:flex relay:w-full relay:overflow-hidden relay:flex-col relay:gap-1"
       >
         {/* Mobile shortcut buttons */}
-        <Flex
-          className="relay:hidden relay:max-[520px]:flex relay:max-[520px]:w-full relay:max-[520px]:gap-2 relay:max-[520px]:mb-2"
-        >
+        <Flex className="relay:hidden relay:max-[520px]:flex relay:max-[520px]:w-full relay:max-[520px]:gap-2 relay:max-[520px]:mb-2">
           <Button
             color="grey"
             size="none"
@@ -170,9 +168,7 @@ const SlippageTabs: FC<SlippageTabsProps> = ({
             )}
             inputStyle={{ color: tokenToColor(slippageRatingColor) }}
           />
-          <Box
-            className="relay:absolute relay:right-2 relay:top-1/2 relay:-translate-y-1/2"
-          >
+          <Box className="relay:absolute relay:right-2 relay:top-1/2 relay:-translate-y-1/2">
             <span style={{ color: tokenToColor(slippageRatingColor) }}>%</span>
           </Box>
         </Flex>
@@ -192,7 +188,7 @@ const SlippageTabs: FC<SlippageTabsProps> = ({
   )
 }
 
-export const SlippageToleranceConfig: FC<SlippageToleranceConfigProps> = ({
+export function SlippageToleranceConfig({
   open: _open,
   setOpen: _setOpen,
   setSlippageTolerance: externalSetValue,
@@ -203,7 +199,7 @@ export const SlippageToleranceConfig: FC<SlippageToleranceConfigProps> = ({
   onOpenSlippageConfig,
   showGearIcon = true,
   showLabel = false
-}) => {
+}: SlippageToleranceConfigProps) {
   const isMobile = useMediaQuery('(max-width: 520px)')
   const [displayValue, setDisplayValue] = useState<string | undefined>(() =>
     currentSlippageTolerance !== undefined
@@ -325,7 +321,16 @@ export const SlippageToleranceConfig: FC<SlippageToleranceConfigProps> = ({
       }}
     >
       {open === false && displayValue && (
-        <Text style="subtitle2" color={slippageRatingColor === 'red11' ? 'red' : slippageRatingColor === 'amber11' ? 'warningSecondary' : undefined}>
+        <Text
+          style="subtitle2"
+          color={
+            slippageRatingColor === 'red11'
+              ? 'red'
+              : slippageRatingColor === 'amber11'
+                ? 'warningSecondary'
+                : undefined
+          }
+        >
           {displayValue}%
         </Text>
       )}

--- a/packages/ui/src/components/common/StepIcon.tsx
+++ b/packages/ui/src/components/common/StepIcon.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import { Flex, ChainIcon } from '../primitives/index.js'
 import {
   FileSignature,
@@ -12,7 +11,7 @@ type StepIconProps = {
   chainId?: number
 }
 
-export const StepIcon: FC<StepIconProps> = ({ stepId, chainId }) => {
+export function StepIcon({ stepId, chainId }: StepIconProps) {
   const getIconForStep = () => {
     if (stepId.includes('approve')) {
       return <FileSignature width={14} height={16} fill="currentColor" />
@@ -38,9 +37,7 @@ export const StepIcon: FC<StepIconProps> = ({ stepId, chainId }) => {
   }
 
   return (
-    <Flex
-      className="relay:rounded-[100px] relay:p-2 relay:w-8 relay:h-8 relay:gap-2"
-    >
+    <Flex className="relay:rounded-[100px] relay:p-2 relay:w-8 relay:h-8 relay:gap-2">
       {getIconForStep()}
     </Flex>
   )

--- a/packages/ui/src/components/common/TokenSelector/ChainFilterRow.tsx
+++ b/packages/ui/src/components/common/TokenSelector/ChainFilterRow.tsx
@@ -1,5 +1,4 @@
 import {
-  type FC,
   useState,
   useRef,
   useCallback,
@@ -31,14 +30,14 @@ export type ChainFilterRowProps = {
   children?: ReactNode
 }
 
-export const ChainFilterRow: FC<ChainFilterRowProps> = ({
+export function ChainFilterRow({
   chain,
   tag,
   onToggleStar,
   showStar = true,
   onAnalyticEvent,
   children
-}) => {
+}: ChainFilterRowProps) {
   const haptic = useHapticEvent()
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -136,9 +135,7 @@ export const ChainFilterRow: FC<ChainFilterRowProps> = ({
           onMouseDown={(e) => e.stopPropagation()}
           onTouchStart={(e) => e.stopPropagation()}
         >
-          <Flex
-            className="relay:flex relay:items-center relay:gap-[6px] relay:p-3 relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-modal-background)] relay:hover:bg-[var(--relay-colors-gray2)]"
-          >
+          <Flex className="relay:flex relay:items-center relay:gap-[6px] relay:p-3 relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-modal-background)] relay:hover:bg-[var(--relay-colors-gray2)]">
             <Box
               className={cn(
                 isStarred

--- a/packages/ui/src/components/common/TokenSelector/ChainFilterSidebar.tsx
+++ b/packages/ui/src/components/common/TokenSelector/ChainFilterSidebar.tsx
@@ -56,7 +56,7 @@ const fuseSearchOptions = {
   keys: ['id', 'name', 'displayName']
 }
 
-export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
+export function ChainFilterSidebar({
   options,
   value,
   isOpen,
@@ -69,7 +69,7 @@ export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
   context,
   onChainStarToggle,
   starredChainIds
-}) => {
+}: ChainFilterSidebarProps) {
   const haptic = useHapticEvent()
   const [chainSearchInput, setChainSearchInput] = useState('')
   const chainFuse = new Fuse(options, fuseSearchOptions)
@@ -127,9 +127,9 @@ export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
                 ? { id: undefined, name: 'All Chains' }
                 : isSameChainSelection
                   ? sameChainOption
-                : options.find(
-                    (chain) => chain.id?.toString() === selectedValue
-                  )
+                  : options.find(
+                      (chain) => chain.id?.toString() === selectedValue
+                    )
             if (chain) {
               haptic('selection')
               onSelect(chain)
@@ -217,9 +217,14 @@ export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
                         ref={isSameChainSelected ? activeChainRef : null}
                         className={cn(
                           'relay:p-2 relay:flex relay:items-center relay:gap-2 relay:relative relay:transition-colors relay:duration-150 relay:outline-none relay:rounded-lg relay:focus-inset',
-                          !isSameChainSelected && 'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
+                          !isSameChainSelected &&
+                            'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
                         )}
-                        style={isSameChainSelected ? { backgroundColor: 'var(--relay-colors-gray6)' } : undefined}
+                        style={
+                          isSameChainSelected
+                            ? { backgroundColor: 'var(--relay-colors-gray6)' }
+                            : undefined
+                        }
                       >
                         <ChainIcon
                           chainId={sameChainOption.id}
@@ -238,7 +243,10 @@ export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
 
               {starredChains.length > 0 && (
                 <>
-                  <Flex align="center" className="relay:px-2 relay:py-1 relay:gap-1">
+                  <Flex
+                    align="center"
+                    className="relay:px-2 relay:py-1 relay:gap-1"
+                  >
                     <Box className="relay:text-[color:var(--relay-colors-primary9)]">
                       <FontAwesomeIcon icon={faStar} width={12} height={12} />
                     </Box>
@@ -286,7 +294,11 @@ export const ChainFilterSidebar: FC<ChainFilterSidebarProps> = ({
                 </>
               )}
 
-              <Text style="subtitle2" color="subtle" className="relay:px-2 relay:py-1">
+              <Text
+                style="subtitle2"
+                color="subtle"
+                className="relay:px-2 relay:py-1"
+              >
                 Chains A-Z
               </Text>
               {alphabeticalChains.map((chain) => {
@@ -410,10 +422,13 @@ const ChainFilterRow: FC<ChainFilterRowProps> = ({
           ref={isActive ? activeChainRef : null}
           className={cn(
             'relay:p-2 relay:flex relay:items-center relay:gap-2 relay:relative relay:transition-colors relay:duration-150 relay:outline-none relay:rounded-lg relay:focus-inset',
-            !isActive && 'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
+            !isActive &&
+              'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
           )}
           style={{
-            ...(isActive ? { backgroundColor: 'var(--relay-colors-gray6)' } : undefined),
+            ...(isActive
+              ? { backgroundColor: 'var(--relay-colors-gray6)' }
+              : undefined),
             boxShadow: 'none'
           }}
         >
@@ -453,9 +468,14 @@ const ChainFilterRow: FC<ChainFilterRowProps> = ({
           }}
           className={cn(
             'relay:p-2 relay:flex relay:items-center relay:gap-2 relay:w-full relay:transition-colors relay:duration-150 relay:outline-none relay:rounded-lg relay:focus-inset',
-            !isActive && 'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
+            !isActive &&
+              'relay:hover:bg-[rgba(var(--relay-colors-gray-rgb,0,0,0),0.1)]'
           )}
-          style={isActive ? { backgroundColor: 'var(--relay-colors-gray6)' } : undefined}
+          style={
+            isActive
+              ? { backgroundColor: 'var(--relay-colors-gray6)' }
+              : undefined
+          }
         >
           <ChainIcon chainId={chain.id} square width={24} height={24} />
           <Text style="subtitle1" ellipsify>
@@ -481,9 +501,7 @@ const ChainFilterRow: FC<ChainFilterRowProps> = ({
           onMouseDown={(e) => e.stopPropagation()}
           onTouchStart={(e) => e.stopPropagation()}
         >
-          <Flex
-            className="relay:flex relay:items-center relay:gap-[6px] relay:p-3 relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-modal-background)] relay:hover:bg-[var(--relay-colors-gray2)]"
-          >
+          <Flex className="relay:flex relay:items-center relay:gap-[6px] relay:p-3 relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-modal-background)] relay:hover:bg-[var(--relay-colors-gray2)]">
             <Box
               className={cn(
                 isStarred

--- a/packages/ui/src/components/common/TokenSelector/ChainShortcuts.tsx
+++ b/packages/ui/src/components/common/TokenSelector/ChainShortcuts.tsx
@@ -19,7 +19,7 @@ type ChainShortcutsProps = {
   context?: 'from' | 'to'
 }
 
-export const ChainShortcuts: FC<ChainShortcutsProps> = ({
+export function ChainShortcuts({
   options,
   value,
   onSelect,
@@ -28,7 +28,7 @@ export const ChainShortcuts: FC<ChainShortcutsProps> = ({
   starredChainIds,
   onAnalyticEvent,
   context
-}) => {
+}: ChainShortcutsProps) {
   const shortcutChains = useMemo(() => {
     const { allChainsOption, starredChains, alphabeticalChains } = groupChains(
       options,

--- a/packages/ui/src/components/common/TokenSelector/CompactChainFilter.tsx
+++ b/packages/ui/src/components/common/TokenSelector/CompactChainFilter.tsx
@@ -1,5 +1,4 @@
 import {
-  type FC,
   useState,
   useMemo,
   forwardRef,
@@ -69,7 +68,7 @@ type CompactChainFilterProps = {
   onAnalyticEvent?: (eventName: string, data?: any) => void
 }
 
-export const CompactChainFilter: FC<CompactChainFilterProps> = ({
+export function CompactChainFilter({
   options,
   value,
   onSelect,
@@ -77,7 +76,7 @@ export const CompactChainFilter: FC<CompactChainFilterProps> = ({
   onChainStarToggle,
   starredChainIds,
   onAnalyticEvent
-}) => {
+}: CompactChainFilterProps) {
   const [open, setOpen] = useState(false)
   const [chainSearchInput, setChainSearchInput] = useState('')
   const searchInputRef = useRef<HTMLInputElement | null>(null)
@@ -221,7 +220,10 @@ export const CompactChainFilter: FC<CompactChainFilterProps> = ({
 
               {starredChains.length > 0 && (
                 <>
-                  <Flex align="center" className="relay:px-2 relay:py-1 relay:gap-1">
+                  <Flex
+                    align="center"
+                    className="relay:px-2 relay:py-1 relay:gap-1"
+                  >
                     <Box className="relay:text-[color:var(--relay-colors-primary9)]">
                       <FontAwesomeIcon icon={faStar} width={12} height={12} />
                     </Box>
@@ -255,7 +257,11 @@ export const CompactChainFilter: FC<CompactChainFilterProps> = ({
                 </>
               )}
 
-              <Text style="subtitle2" color="subtle" className="relay:px-2 relay:py-1">
+              <Text
+                style="subtitle2"
+                color="subtle"
+                className="relay:px-2 relay:py-1"
+              >
                 Chains A-Z
               </Text>
               {alphabeticalChains.map((chain: ChainFilterValue) => {

--- a/packages/ui/src/components/common/TokenSelector/MobileChainSelector.tsx
+++ b/packages/ui/src/components/common/TokenSelector/MobileChainSelector.tsx
@@ -58,7 +58,7 @@ const fuseSearchOptions = {
   keys: ['id', 'name', 'displayName']
 }
 
-export const MobileChainSelector: FC<MobileChainSelectorProps> = ({
+export function MobileChainSelector({
   options,
   value,
   sameChainOption,
@@ -70,7 +70,7 @@ export const MobileChainSelector: FC<MobileChainSelectorProps> = ({
   context,
   onChainStarToggle,
   starredChainIds
-}) => {
+}: MobileChainSelectorProps) {
   const haptic = useHapticEvent()
   const [chainSearchInput, setChainSearchInput] = useState('')
   const chainFuse = new Fuse(options, fuseSearchOptions)
@@ -105,15 +105,9 @@ export const MobileChainSelector: FC<MobileChainSelectorProps> = ({
   )
 
   return (
-    <Flex
-      direction="column"
-      className="relay:w-full relay:h-full relay:gap-3"
-    >
+    <Flex direction="column" className="relay:w-full relay:h-full relay:gap-3">
       {/* Header with back button, search, and close */}
-      <Flex
-        align="center"
-        className="relay:gap-1 relay:w-full"
-      >
+      <Flex align="center" className="relay:gap-1 relay:w-full">
         <Button
           color="ghost"
           size="none"
@@ -162,9 +156,9 @@ export const MobileChainSelector: FC<MobileChainSelectorProps> = ({
                 ? { id: undefined, name: 'All Chains' }
                 : isSameChainSelection
                   ? sameChainOption
-                : options.find(
-                    (chain) => chain.id?.toString() === selectedValue
-                  )
+                  : options.find(
+                      (chain) => chain.id?.toString() === selectedValue
+                    )
             if (chain) {
               haptic('selection')
               const fromStarredList =
@@ -455,9 +449,7 @@ const MobileChainRow: FC<MobileChainRowProps> = ({
           onMouseDown={(e) => e.stopPropagation()}
           onTouchStart={(e) => e.stopPropagation()}
         >
-          <Flex
-            className="relay:items-center relay:gap-[8px] relay:p-[8px] relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-gray1)] relay:border relay:border-solid relay:border-[var(--relay-colors-subtle-border-color)] relay:hover:bg-[var(--relay-colors-gray2)]"
-          >
+          <Flex className="relay:items-center relay:gap-[8px] relay:p-[8px] relay:rounded-[12px] relay:cursor-pointer relay:bg-[var(--relay-colors-gray1)] relay:border relay:border-solid relay:border-[var(--relay-colors-subtle-border-color)] relay:hover:bg-[var(--relay-colors-gray2)]">
             <Box
               className={cn(
                 isStarred

--- a/packages/ui/src/components/common/TokenSelector/PaymentTokenList.tsx
+++ b/packages/ui/src/components/common/TokenSelector/PaymentTokenList.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from 'react'
+import { useState } from 'react'
 import {
   Flex,
   Text,
@@ -26,7 +26,7 @@ type PaymentTokenListProps = {
   opacity?: number
 }
 
-export const PaymentTokenList: FC<PaymentTokenListProps> = ({
+export function PaymentTokenList({
   title,
   tokens: rawTokens,
   isLoading,
@@ -35,7 +35,7 @@ export const PaymentTokenList: FC<PaymentTokenListProps> = ({
   showMoreButton,
   limit = 5,
   opacity = 1
-}) => {
+}: PaymentTokenListProps) {
   const [tokensExpanded, setTokensExpanded] = useState(false)
   const tokens =
     showMoreButton && rawTokens && rawTokens.length > limit && !tokensExpanded
@@ -51,9 +51,7 @@ export const PaymentTokenList: FC<PaymentTokenListProps> = ({
             align="center"
             className="relay:gap-2 relay:py-2 relay:px-0 relay:w-full relay:min-[660px]:px-2"
           >
-            <Skeleton
-              className="relay:w-[40px] relay:h-[40px] relay:rounded-[50%] relay:shrink-0"
-            />
+            <Skeleton className="relay:w-[40px] relay:h-[40px] relay:rounded-[50%] relay:shrink-0" />
             <Flex direction="column" className="relay:gap-[2px] relay:grow">
               <Skeleton className="relay:w-[60%] relay:h-[16px]" />
               <Skeleton className="relay:w-[40%] relay:h-[16px]" />

--- a/packages/ui/src/components/common/TokenSelector/SuggestedTokens.tsx
+++ b/packages/ui/src/components/common/TokenSelector/SuggestedTokens.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import {
   AccessibleListItem,
   Button,
@@ -16,11 +15,11 @@ type SuggestedTokensProps = {
   onSelect: (token: Token) => void
 }
 
-export const SuggestedTokens: FC<SuggestedTokensProps> = ({
+export function SuggestedTokens({
   chainId,
   depositAddressOnly,
   onSelect
-}) => {
+}: SuggestedTokensProps) {
   const { chains } = useInternalRelayChains()
 
   const chain = chains?.find((c) => c.id === chainId)

--- a/packages/ui/src/components/common/TokenSelector/TagPill.tsx
+++ b/packages/ui/src/components/common/TokenSelector/TagPill.tsx
@@ -1,11 +1,10 @@
-import { type FC } from 'react'
 import { Text } from '../../primitives/index.js'
 
 type TagPillProps = {
   tag: string
 }
 
-export const TagPill: FC<TagPillProps> = ({ tag }) => {
+export function TagPill({ tag }: TagPillProps) {
   return (
     <Text
       style="subtitle3"

--- a/packages/ui/src/components/common/TokenSelector/TokenList.tsx
+++ b/packages/ui/src/components/common/TokenSelector/TokenList.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from 'react'
+import { useState } from 'react'
 import {
   Flex,
   Text,
@@ -26,14 +26,14 @@ type TokenListProps = {
   showMoreButton?: boolean
 }
 
-export const TokenList: FC<TokenListProps> = ({
+export function TokenList({
   title,
   tokens: rawTokens,
   isLoading,
   isLoadingBalances,
   chainFilterId,
   showMoreButton
-}) => {
+}: TokenListProps) {
   const [tokensExpanded, setTokensExpanded] = useState(false)
   const tokens =
     showMoreButton && rawTokens && rawTokens.length > 4 && !tokensExpanded
@@ -49,9 +49,7 @@ export const TokenList: FC<TokenListProps> = ({
             align="center"
             className="relay:gap-2 relay:p-2 relay:w-full"
           >
-            <Skeleton
-              className="relay:w-[40px] relay:h-[40px] relay:!rounded-full relay:shrink-0"
-            />
+            <Skeleton className="relay:w-[40px] relay:h-[40px] relay:!rounded-full relay:shrink-0" />
             <Flex direction="column" className="relay:gap-[2px] relay:grow">
               <Skeleton className="relay:w-[60%] relay:h-[16px]" />
               <Skeleton className="relay:w-[40%] relay:h-[16px]" />

--- a/packages/ui/src/components/common/TokenSelector/triggers/PaymentMethodTrigger.tsx
+++ b/packages/ui/src/components/common/TokenSelector/triggers/PaymentMethodTrigger.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { Token } from '../../../../types/index.js'
 import {
   Button,
@@ -40,13 +39,13 @@ const normalizeAddress = (address?: string) => {
   return address.startsWith('0x') ? address.toLowerCase() : address
 }
 
-export const PaymentMethodTrigger: FC<PaymentMethodTriggerProps> = ({
+export function PaymentMethodTrigger({
   token,
   address,
   testId,
   balanceLabel = 'available',
   placeholderText = 'Select Token'
-}) => {
+}: PaymentMethodTriggerProps) {
   const relayClient = useRelayClient()
 
   const normalizedAddress = normalizeAddress(address)
@@ -103,9 +102,7 @@ export const PaymentMethodTrigger: FC<PaymentMethodTriggerProps> = ({
               {token.symbol}
             </Text>
             {showSkeleton ? (
-              <Skeleton
-                className="relay:w-[70px] relay:h-[12px] relay:rounded-[4px]"
-              />
+              <Skeleton className="relay:w-[70px] relay:h-[12px] relay:rounded-[4px]" />
             ) : (
               <Text
                 style="subtitle3"

--- a/packages/ui/src/components/common/TokenSelector/triggers/TokenTrigger.tsx
+++ b/packages/ui/src/components/common/TokenSelector/triggers/TokenTrigger.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { Token } from '../../../../types/index.js'
 import {
   Button,
@@ -18,12 +17,12 @@ type TokenTriggerProps = {
   testId?: string
 }
 
-export const TokenTrigger: FC<TokenTriggerProps> = ({
+export function TokenTrigger({
   token,
   locked,
   address,
   testId
-}) => {
+}: TokenTriggerProps) {
   const relayClient = useRelayClient()
   const chain = relayClient?.chains?.find(
     (chain) => chain.id === token?.chainId

--- a/packages/ui/src/components/common/TransactionModal/DepositAddressModal.tsx
+++ b/packages/ui/src/components/common/TransactionModal/DepositAddressModal.tsx
@@ -35,9 +35,9 @@ type DepositAddressModalProps = {
   onSuccess?: (data: Execute) => void
 }
 
-export const DepositAddressModal: FC<DepositAddressModalProps> = (
-  depositAddressModalProps
-) => {
+export function DepositAddressModal(
+  depositAddressModalProps: DepositAddressModalProps
+) {
   const {
     open,
     address,

--- a/packages/ui/src/components/common/TransactionModal/DepositAddressModalRenderer.tsx
+++ b/packages/ui/src/components/common/TransactionModal/DepositAddressModalRenderer.tsx
@@ -1,5 +1,4 @@
 import {
-  type FC,
   useMemo,
   useState,
   useEffect,
@@ -91,7 +90,7 @@ type Props = {
   onSwapError?: (error: string, data?: Execute) => void
 }
 
-export const DepositAddressModalRenderer: FC<Props> = ({
+export function DepositAddressModalRenderer({
   open,
   address,
   fromChain,
@@ -105,7 +104,7 @@ export const DepositAddressModalRenderer: FC<Props> = ({
   onSuccess,
   onAnalyticEvent,
   onSwapError
-}) => {
+}: Props) {
   const haptic = useHapticEvent()
   const [quoteData, setQuoteData] = useState<Execute | null>(null)
   const [fetchingQuote, setFetchingQuote] = useState(false)
@@ -284,7 +283,10 @@ export const DepositAddressModalRenderer: FC<Props> = ({
       }
       setProgressStep(TransactionProgressStep.Success)
       invalidateBalanceQueries()
-    } else if (executionStatus?.status === 'pending' || executionStatus?.status === 'depositing') {
+    } else if (
+      executionStatus?.status === 'pending' ||
+      executionStatus?.status === 'depositing'
+    ) {
       const timeEstimateMs =
         ((quote?.details?.timeEstimate ?? 0) +
           (fromChain && fromChain.id === bitcoin.id ? 600 : 0)) *

--- a/packages/ui/src/components/common/TransactionModal/TransactionModal.tsx
+++ b/packages/ui/src/components/common/TransactionModal/TransactionModal.tsx
@@ -46,9 +46,7 @@ type TransactionModalProps = {
   invalidateQuoteQuery: () => void
 }
 
-export const TransactionModal: FC<TransactionModalProps> = (
-  transactionModalProps
-) => {
+export function TransactionModal(transactionModalProps: TransactionModalProps) {
   const {
     quote,
     steps,

--- a/packages/ui/src/components/common/TransactionModal/TransactionModalRenderer.tsx
+++ b/packages/ui/src/components/common/TransactionModal/TransactionModalRenderer.tsx
@@ -1,5 +1,4 @@
 import {
-  type FC,
   useMemo,
   useState,
   useEffect,
@@ -82,7 +81,7 @@ type Props = {
   onValidating?: (quote: Execute) => void
 }
 
-export const TransactionModalRenderer: FC<Props> = ({
+export function TransactionModalRenderer({
   open,
   slippageTolerance,
   wallet,
@@ -93,7 +92,7 @@ export const TransactionModalRenderer: FC<Props> = ({
   children,
   onSuccess,
   onValidating
-}) => {
+}: Props) {
   const relayClient = useRelayClient()
   const chainId = quote?.details?.currencyIn?.currency?.chainId || 1
 

--- a/packages/ui/src/components/common/TransactionModal/steps/ApprovalPlusSwapStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/ApprovalPlusSwapStep.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import {
   Flex,
   Text,
@@ -29,14 +28,14 @@ type ApprovalPlusSwapStepProps = {
   steps: Execute['steps'] | null
 }
 
-export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
+export function ApprovalPlusSwapStep({
   fromToken,
   toToken,
   quote,
   fromAmountFormatted,
   toAmountFormatted,
   steps
-}) => {
+}: ApprovalPlusSwapStepProps) {
   const details = quote?.details
   const relayClient = useRelayClient()
 
@@ -191,9 +190,7 @@ export const ApprovalPlusSwapStep: FC<ApprovalPlusSwapStepProps> = ({
 
                 <Flex>
                   {isCurrentStep && hasTxHash ? (
-                    <LoadingSpinner
-                      className="relay:h-4 relay:w-4 relay:fill-[var(--relay-colors-gray9)]"
-                    />
+                    <LoadingSpinner className="relay:h-4 relay:w-4 relay:fill-[var(--relay-colors-gray9)]" />
                   ) : step?.items?.every(
                       (item) => item.status === 'complete'
                     ) ? (

--- a/packages/ui/src/components/common/TransactionModal/steps/ErrorStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/ErrorStep.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import { Anchor, Box, Button, Flex, Text } from '../../../primitives/index.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons/faCircleExclamation'
@@ -33,7 +32,7 @@ type ErrorStepProps = {
   onOpenChange: (open: boolean) => void
 }
 
-export const ErrorStep: FC<ErrorStepProps> = ({
+export function ErrorStep({
   error,
   address,
   allTxHashes,
@@ -45,7 +44,7 @@ export const ErrorStep: FC<ErrorStepProps> = ({
   fromAmountFormatted,
   toAmountFormatted,
   onOpenChange
-}) => {
+}: ErrorStepProps) {
   const parsedError = JSONToError(error)
   const errorMessage = transaction?.data?.failReason ?? parsedError?.message
   const isRefund =

--- a/packages/ui/src/components/common/TransactionModal/steps/SwapConfirmationStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/SwapConfirmationStep.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC } from 'react'
+import { useMemo } from 'react'
 import { Flex, Text, ChainTokenIcon, Box } from '../../../primitives/index.js'
 import { LoadingSpinner } from '../../LoadingSpinner.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -26,7 +26,7 @@ type SwapConfirmationStepProps = {
   linkedWallets?: any[]
 }
 
-export const SwapConfirmationStep: FC<SwapConfirmationStepProps> = ({
+export function SwapConfirmationStep({
   fromToken,
   toToken,
   fromChain,
@@ -37,7 +37,7 @@ export const SwapConfirmationStep: FC<SwapConfirmationStepProps> = ({
   steps,
   currentAddress,
   linkedWallets
-}) => {
+}: SwapConfirmationStepProps) {
   const operation = quote?.details?.operation || 'swap'
 
   const { formattedSteps } = useMemo(
@@ -177,7 +177,7 @@ export type StepRowProps = {
   showSubTextSpinner?: boolean
 }
 
-export const StepRow: FC<StepRowProps> = ({
+export function StepRow({
   id,
   action,
   isActive,
@@ -189,7 +189,7 @@ export const StepRow: FC<StepRowProps> = ({
   subText,
   subTextColor,
   showSubTextSpinner
-}) => {
+}: StepRowProps) {
   const relayClient = useRelayClient()
   const chains = relayClient?.chains
   return (
@@ -206,13 +206,14 @@ export const StepRow: FC<StepRowProps> = ({
                 : 'relay:bg-[var(--relay-colors-gray5)]'
           )}
           style={{
-            color: isActive && !isCompleted
-              ? 'var(--relay-colors-primary11)'
-              : isCompleted
-                ? 'var(--relay-colors-green11)'
-                : isActive
-                  ? 'var(--relay-colors-primary11)'
-                  : 'var(--relay-colors-gray9)',
+            color:
+              isActive && !isCompleted
+                ? 'var(--relay-colors-primary11)'
+                : isCompleted
+                  ? 'var(--relay-colors-green11)'
+                  : isActive
+                    ? 'var(--relay-colors-primary11)'
+                    : 'var(--relay-colors-gray9)',
             animation:
               isActive && !isCompleted
                 ? 'relay-pulse-shadow 1s infinite alternate-reverse'
@@ -245,10 +246,7 @@ export const StepRow: FC<StepRowProps> = ({
 
                   return (
                     <Flex align="center" className="relay:gap-[4px]">
-                      <Text
-                        style="subtitle3"
-                        color="green"
-                      >
+                      <Text style="subtitle3" color="green">
                         {successText}:
                       </Text>
                       {hashPart &&
@@ -259,18 +257,12 @@ export const StepRow: FC<StepRowProps> = ({
                             rel="noopener noreferrer"
                             className="relay:no-underline"
                           >
-                            <Text
-                              style="subtitle3"
-                              color="primary"
-                            >
+                            <Text style="subtitle3" color="primary">
                               {hashPart}
                             </Text>
                           </a>
                         ) : (
-                          <Text
-                            style="subtitle3"
-                            color="primary"
-                          >
+                          <Text style="subtitle3" color="primary">
                             {hashPart}
                           </Text>
                         ))}
@@ -294,10 +286,7 @@ export const StepRow: FC<StepRowProps> = ({
 
                   return (
                     <Flex align="center" className="relay:gap-[4px]">
-                      <Text
-                        style="subtitle3"
-                        color="primary"
-                      >
+                      <Text style="subtitle3" color="primary">
                         {labelText}:
                       </Text>
                       {hashPart &&
@@ -308,18 +297,12 @@ export const StepRow: FC<StepRowProps> = ({
                             rel="noopener noreferrer"
                             className="relay:no-underline"
                           >
-                            <Text
-                              style="subtitle3"
-                              color="primary"
-                            >
+                            <Text style="subtitle3" color="primary">
                               {hashPart}
                             </Text>
                           </a>
                         ) : (
-                          <Text
-                            style="subtitle3"
-                            color="primary"
-                          >
+                          <Text style="subtitle3" color="primary">
                             {hashPart}
                           </Text>
                         ))}

--- a/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/SwapSuccessStep.tsx
@@ -1,4 +1,4 @@
-import { useContext, type FC } from 'react'
+import { useContext } from 'react'
 import {
   Box,
   Button,
@@ -51,7 +51,7 @@ type SwapSuccessStepProps = {
   currentCheckStatus?: ExecuteStepItem['checkStatus']
 }
 
-export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
+export function SwapSuccessStep({
   fromToken,
   toToken,
   fromAmountFormatted,
@@ -67,7 +67,7 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
   requestId,
   isGasSponsored,
   currentCheckStatus
-}) => {
+}: SwapSuccessStepProps) {
   const relayClient = useRelayClient()
   const haptic = useHapticEvent()
   const isWrap = details?.operation === 'wrap'
@@ -198,18 +198,13 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
               />
             </svg>
 
-            <Box
-              className="relay:z-[1] relay:text-[color:var(--relay-colors-amber9)] relay:mr-2"
-            >
+            <Box className="relay:z-[1] relay:text-[color:var(--relay-colors-amber9)] relay:mr-2">
               <FontAwesomeIcon icon={faClockFour} style={{ height: 32 }} />
             </Box>
           </Flex>
         </div>
 
-        <Text
-          style="subtitle1"
-          className="relay:my-4 relay:text-center"
-        >
+        <Text style="subtitle1" className="relay:my-4 relay:text-center">
           {isBitcoinOrigin || isBitcoinDestination
             ? `Bitcoin confirmation takes ${estimatedMinutes} minutes. Track progress on the transaction page.`
             : `Processing bridge, this will take ~${estimatedMinutes} ${estimatedMinutes === 1 ? 'min' : 'mins'}.`}
@@ -217,7 +212,10 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
 
         <Flex align="center" className="relay:gap-2 relay:mb-[24px]">
           {fromChain ? (
-            <Pill color="gray" className="relay:items-center relay:py-2 relay:px-3">
+            <Pill
+              color="gray"
+              className="relay:items-center relay:py-2 relay:px-3"
+            >
               <ChainTokenIcon
                 chainId={fromChain.id}
                 tokenlogoURI={fromTokenLogoUri}
@@ -236,7 +234,10 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
             <FontAwesomeIcon style={{ width: 14 }} icon={faArrowRight} />
           </Flex>
           {toChain ? (
-            <Pill color="gray" className="relay:items-center relay:py-2 relay:px-3">
+            <Pill
+              color="gray"
+              className="relay:items-center relay:py-2 relay:px-3"
+            >
               <ChainTokenIcon
                 chainId={toChain.id}
                 tokenlogoURI={toTokenLogoUri}
@@ -406,9 +407,7 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
                     chainRadius={2.5}
                   />
                   {isLoadingTransaction ? (
-                    <Skeleton
-                      className="relay:h-[24px] relay:w-[60px] relay:bg-[var(--relay-colors-gray5)]"
-                    />
+                    <Skeleton className="relay:h-[24px] relay:w-[60px] relay:bg-[var(--relay-colors-gray5)]" />
                   ) : (
                     <Text style="h6">
                       {_fromAmountFormatted} {_fromToken.symbol}
@@ -454,9 +453,7 @@ export const SwapSuccessStep: FC<SwapSuccessStepProps> = ({
                     chainRadius={2.5}
                   />
                   {isLoadingTransaction ? (
-                    <Skeleton
-                      className="relay:h-[24px] relay:w-[60px] relay:bg-[var(--relay-colors-gray5)]"
-                    />
+                    <Skeleton className="relay:h-[24px] relay:w-[60px] relay:bg-[var(--relay-colors-gray5)]" />
                   ) : (
                     <Text style="h6">
                       {_toAmountFormatted} {_toToken.symbol}

--- a/packages/ui/src/components/common/TransactionModal/steps/TransactionsByChain.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/TransactionsByChain.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC } from 'react'
+import { useMemo } from 'react'
 import { useRelayClient } from '../../../../hooks/index.js'
 import type { TxHashes } from '../TransactionModalRenderer.js'
 import {
@@ -26,14 +26,14 @@ type TransactionsByChainProps = {
   fillTx?: { txHash: string; chainId: number } | null
 }
 
-export const TransactionsByChain: FC<TransactionsByChainProps> = ({
+export function TransactionsByChain({
   allTxHashes,
   fromChain,
   toChain,
   refundData,
   isSolverStatusTimeout,
   fillTx
-}) => {
+}: TransactionsByChainProps) {
   const relayClient = useRelayClient()
   const refundChain = refundData
     ? relayClient?.chains.find(

--- a/packages/ui/src/components/common/TransactionModal/steps/WaitingForDepositStep.tsx
+++ b/packages/ui/src/components/common/TransactionModal/steps/WaitingForDepositStep.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import {
   Button,
   ChainIcon,
@@ -37,13 +36,13 @@ type WaitingForDepositStepProps = {
   depositAddress?: string
 }
 
-export const WaitingForDepositStep: FC<WaitingForDepositStepProps> = ({
+export function WaitingForDepositStep({
   fromToken,
   fromChain,
   fromAmountFormatted,
   isFetchingQuote,
   depositAddress
-}) => {
+}: WaitingForDepositStepProps) {
   const qrcodeUrl = generateQrWalletDeeplink(
     fromChain?.vmType,
     fromAmountFormatted,
@@ -152,7 +151,13 @@ export const WaitingForDepositStep: FC<WaitingForDepositStepProps> = ({
                         boxShadow: '0px 1px 5px rgba(0,0,0,0.2)'
                       }}
                     >
-                      <div style={{ position: 'relative', width: 105, height: 105 }}>
+                      <div
+                        style={{
+                          position: 'relative',
+                          width: 105,
+                          height: 105
+                        }}
+                      >
                         <QRCodeCanvas
                           value={qrcodeUrl}
                           width={105}
@@ -215,9 +220,7 @@ export const WaitingForDepositStep: FC<WaitingForDepositStepProps> = ({
         disabled={true}
         className="relay:text-[color:var(--relay-colors-button-disabled-color)_!important] relay:mt-2 relay:justify-center"
       >
-        <LoadingSpinner
-          className="relay:h-4 relay:w-4 relay:fill-[var(--relay-colors-button-disabled-color)]"
-        />
+        <LoadingSpinner className="relay:h-4 relay:w-4 relay:fill-[var(--relay-colors-button-disabled-color)]" />
         Waiting for you to transfer funds
       </Button>
     </>

--- a/packages/ui/src/components/common/UnverifiedTokenModal.tsx
+++ b/packages/ui/src/components/common/UnverifiedTokenModal.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { Modal } from './Modal.js'
 import type { Token } from '../../types/index.js'
 import { Anchor, Box, Button, Flex, Text } from '../primitives/index.js'
@@ -25,14 +24,14 @@ type UnverifiedTokenModalProps = {
   onAnalyticEvent?: (eventName: string, data?: any) => void
 }
 
-export const UnverifiedTokenModal: FC<UnverifiedTokenModalProps> = ({
+export function UnverifiedTokenModal({
   open,
   onOpenChange,
   data,
   onAcceptToken,
   onDecline,
   onAnalyticEvent
-}) => {
+}: UnverifiedTokenModalProps) {
   const haptic = useHapticEvent()
   const client = useRelayClient()
   const chain = client?.chains?.find(

--- a/packages/ui/src/components/primitives/AccessibleList.tsx
+++ b/packages/ui/src/components/primitives/AccessibleList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type FC } from 'react'
+import React, { forwardRef } from 'react'
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import { cn } from '../../utils/cn.js'
 
@@ -8,11 +8,11 @@ type AccessibleListProps = {
   className?: string
 }
 
-export const AccessibleList: FC<AccessibleListProps> = ({
+export function AccessibleList({
   children,
   onSelect,
   className
-}) => {
+}: AccessibleListProps) {
   return (
     <ToggleGroup.Root
       type="single"

--- a/packages/ui/src/components/primitives/ChainTokenIcon.tsx
+++ b/packages/ui/src/components/primitives/ChainTokenIcon.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import ChainIcon from './ChainIcon.js'
 import Text from './Text.js'
 import { cn } from '../../utils/cn.js'
@@ -34,7 +33,7 @@ const SIZES = {
   }
 } as const
 
-export const ChainTokenIcon: FC<ChainTokenProps> = ({
+export function ChainTokenIcon({
   chainId,
   tokenlogoURI,
   tokenSymbol,
@@ -42,7 +41,7 @@ export const ChainTokenIcon: FC<ChainTokenProps> = ({
   size = 'md',
   chainRadius = 4,
   chainIconSize
-}) => {
+}: ChainTokenProps) {
   const isValidTokenLogo = tokenlogoURI && tokenlogoURI !== 'missing.png'
   const dimensions = SIZES[size]
   const chainSize = chainIconSize ?? dimensions.chain

--- a/packages/ui/src/components/primitives/SlippageButton.tsx
+++ b/packages/ui/src/components/primitives/SlippageButton.tsx
@@ -1,4 +1,3 @@
-import { type FC } from 'react'
 import Button from './Button.js'
 import Text from './Text.js'
 
@@ -19,10 +18,10 @@ const convertBpsToPercent = (bps?: string) => {
   return formatted.replace(/\.0+$/, '').replace(/\.00$/, '')
 }
 
-export const SlippageButton: FC<SlippageButtonProps> = ({
+export function SlippageButton({
   slippageTolerance,
   onOpenSlippageConfig
-}) => {
+}: SlippageButtonProps) {
   const resolvedValue = convertBpsToPercent(slippageTolerance)
   const displayValue = resolvedValue ? `${resolvedValue}%` : 'Auto'
 

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/OnrampModal.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/OnrampModal.tsx
@@ -4,7 +4,7 @@ import {
   type Execute,
   type RelayChain
 } from '@relayprotocol/relay-sdk'
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Modal } from '../../../common/Modal.js'
 import type { FiatCurrency, Token } from '../../../../types/index.js'
 import useRelayClient from '../../../../hooks/useRelayClient.js'
@@ -74,7 +74,7 @@ type OnrampModalProps = {
 
 type TxHashes = { txHash: string; chainId: number }[]
 
-export const OnrampModal: FC<OnrampModalProps> = ({
+export function OnrampModal({
   open,
   amount,
   amountFormatted,
@@ -96,7 +96,7 @@ export const OnrampModal: FC<OnrampModalProps> = ({
   onSuccess,
   onError,
   onOpenChange
-}) => {
+}: OnrampModalProps) {
   const haptic = useHapticEvent()
   const [swapError, setSwapError] = useState<Error | null>(null)
   const [step, setStep] = useState<OnrampStep>(OnrampStep.Confirming)
@@ -230,9 +230,7 @@ export const OnrampModal: FC<OnrampModalProps> = ({
     client?.baseApiUrl,
     {
       enabled:
-        depositAddress !== undefined &&
-        step === OnrampStep.Processing &&
-        open,
+        depositAddress !== undefined && step === OnrampStep.Processing && open,
       refetchInterval(query) {
         const observableStates = ['waiting', 'pending']
 

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampConfirmingStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampConfirmingStep.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import {
   Anchor,
   Button,
@@ -29,7 +28,7 @@ type OnrampConfirmingStepProps = {
   setStep: (step: OnrampStep) => void
 }
 
-export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
+export function OnrampConfirmingStep({
   toToken,
   fromToken,
   fromChain,
@@ -43,13 +42,10 @@ export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
   isFetchingQuote,
   onAnalyticEvent,
   setStep
-}) => {
+}: OnrampConfirmingStepProps) {
   const haptic = useHapticEvent()
   return (
-    <Flex
-      direction="column"
-      className="relay:w-full relay:h-full relay:gap-4"
-    >
+    <Flex direction="column" className="relay:w-full relay:h-full relay:gap-4">
       <Text style="h6">
         Buy {toToken?.symbol} ({toChain?.displayName})
       </Text>
@@ -68,9 +64,7 @@ export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
             your card
           </Text>
         </Flex>
-        <div
-          className="relay:ml-[16px] relay:h-[24px] relay:w-px relay:bg-[var(--relay-colors-gray5)] relay:mt-[5px] relay:mb-[5px]"
-        />
+        <div className="relay:ml-[16px] relay:h-[24px] relay:w-px relay:bg-[var(--relay-colors-gray5)] relay:mt-[5px] relay:mb-[5px]" />
         <Flex align="center" className="relay:gap-2">
           <ChainTokenIcon
             chainId={toToken?.chainId}
@@ -114,9 +108,7 @@ export const OnrampConfirmingStep: FC<OnrampConfirmingStepProps> = ({
         }}
       >
         {!depositAddress || isFetchingQuote ? (
-          <LoadingSpinner
-            className="relay:h-[16px] relay:w-[16px] relay:fill-[var(--relay-colors-button-disabled-color)]"
-          />
+          <LoadingSpinner className="relay:h-[16px] relay:w-[16px] relay:fill-[var(--relay-colors-button-disabled-color)]" />
         ) : (
           `Purchase ${fromToken?.symbol} (${fromChain?.displayName})`
         )}

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampMoonPayStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampMoonPayStep.tsx
@@ -1,9 +1,5 @@
-import { lazy, memo, Suspense, useEffect, type FC } from 'react'
-import {
-  ChainTokenIcon,
-  Flex,
-  Text
-} from '../../../../primitives/index.js'
+import { lazy, memo, Suspense, useEffect } from 'react'
+import { ChainTokenIcon, Flex, Text } from '../../../../primitives/index.js'
 import type { FiatCurrency, Token } from '../../../../../types/index.js'
 import { OnrampProcessingStep, OnrampStep } from '../OnrampModal.js'
 import type { RelayChain } from '@relayprotocol/relay-sdk'
@@ -59,7 +55,7 @@ const MoonPayBuyWidget = memo(
 
 arbitrum
 
-export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
+export function OnrampMoonPayStep({
   step,
   processingStep,
   toToken,
@@ -84,7 +80,7 @@ export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
   moonpayOnUrlSignatureRequested,
   onPassthroughSuccess,
   onError
-}) => {
+}: OnrampMoonPayStepProps) {
   const moonPayExternalId = !isPassthrough
     ? (quoteRequestId ?? undefined)
     : passthroughExternalId
@@ -200,9 +196,7 @@ export const OnrampMoonPayStep: FC<OnrampMoonPayStepProps> = ({
           align="center"
           className="relay:w-full relay:overflow-hidden relay:p-4 relay:gap-2 relay:mb-2 relay:rounded-widget-card relay:border relay:border-solid relay:border-[var(--relay-colors-subtle-border-color)]"
         >
-          <div
-            className="relay:relative relay:shrink-0 relay:w-[48px] relay:h-[52px]"
-          >
+          <div className="relay:relative relay:shrink-0 relay:w-[48px] relay:h-[52px]">
             <div className="relay:absolute relay:top-0 relay:right-0 relay:z-[1]">
               <ChainTokenIcon
                 chainId={toToken?.chainId}

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingStepUI.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampProcessingStepUI.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Anchor,
   Box,
@@ -31,7 +31,7 @@ type OnrampProcessingStepUIProps = {
   requestId?: string
 }
 
-export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
+export function OnrampProcessingStepUI({
   toToken,
   fromToken,
   fromChain,
@@ -42,7 +42,7 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
   processingStep,
   baseTransactionUrl,
   requestId
-}) => {
+}: OnrampProcessingStepUIProps) {
   const [delayedMoonpayTx, setDelayedMoonpayTx] = useState(false)
 
   useEffect(() => {
@@ -65,10 +65,7 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
   }, [processingStep])
 
   return (
-    <Flex
-      direction="column"
-      className="relay:w-full relay:h-full"
-    >
+    <Flex direction="column" className="relay:w-full relay:h-full">
       <Text style="h6" className="relay:mb-4">
         Processing Transaction
       </Text>
@@ -77,12 +74,14 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
         className="relay:w-full relay:overflow-hidden relay:p-4 relay:mb-4 relay:rounded-widget-card relay:border relay:border-solid relay:border-[var(--relay-colors-subtle-border-color)]"
       >
         <Flex align="center" className="relay:gap-2">
-          <div style={{
-            filter:
-              processingStep === OnrampProcessingStep.Relaying
-                ? 'grayscale(1)'
-                : 'none'
-          }}>
+          <div
+            style={{
+              filter:
+                processingStep === OnrampProcessingStep.Relaying
+                  ? 'grayscale(1)'
+                  : 'none'
+            }}
+          >
             <ChainTokenIcon
               chainId={fromToken?.chainId}
               tokenlogoURI={fromToken?.logoURI}
@@ -121,9 +120,7 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
               <FontAwesomeIcon icon={faCheck} style={{ height: 16 }} />
             </Box>
           ) : (
-            <LoadingSpinner
-              className="relay:h-[20px] relay:w-[20px] relay:fill-[var(--relay-colors-gray9)] relay:ml-auto"
-            />
+            <LoadingSpinner className="relay:h-[20px] relay:w-[20px] relay:fill-[var(--relay-colors-gray9)] relay:ml-auto" />
           )}
         </Flex>
         {processingStep === OnrampProcessingStep.Finalizing ? (
@@ -165,19 +162,16 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
           )
         ) : null}
 
-        <div
-          className="relay:ml-[16px] relay:h-[24px] relay:w-px relay:bg-[var(--relay-colors-gray5)] relay:mt-[5px] relay:mb-[5px]"
-        />
-        <Flex
-          align="center"
-          className="relay:gap-2"
-        >
-          <div style={{
-            filter:
-              processingStep === OnrampProcessingStep.Relaying
-                ? 'none'
-                : 'grayscale(1)'
-          }}>
+        <div className="relay:ml-[16px] relay:h-[24px] relay:w-px relay:bg-[var(--relay-colors-gray5)] relay:mt-[5px] relay:mb-[5px]" />
+        <Flex align="center" className="relay:gap-2">
+          <div
+            style={{
+              filter:
+                processingStep === OnrampProcessingStep.Relaying
+                  ? 'none'
+                  : 'grayscale(1)'
+            }}
+          >
             <ChainTokenIcon
               chainId={toToken?.chainId}
               tokenlogoURI={toToken?.logoURI}
@@ -207,9 +201,7 @@ export const OnrampProcessingStepUI: FC<OnrampProcessingStepUIProps> = ({
             ) : null}
           </Flex>
           {processingStep === OnrampProcessingStep.Relaying ? (
-            <LoadingSpinner
-              className="relay:h-[16px] relay:w-[16px] relay:fill-[var(--relay-colors-gray9)] relay:ml-auto"
-            />
+            <LoadingSpinner className="relay:h-[16px] relay:w-[16px] relay:fill-[var(--relay-colors-gray9)] relay:ml-auto" />
           ) : null}
         </Flex>
       </Flex>

--- a/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampSuccessStep.tsx
+++ b/packages/ui/src/components/widgets/OnrampWidget/modals/steps/OnrampSuccessStep.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import {
   Anchor,
   Box,
@@ -26,7 +25,7 @@ type OnrampSuccessStepProps = {
   onOpenChange: (open: boolean) => void
 }
 
-export const OnrampSuccessStep: FC<OnrampSuccessStepProps> = ({
+export function OnrampSuccessStep({
   toToken,
   moonpayTxUrl,
   isLoadingTransaction,
@@ -35,12 +34,9 @@ export const OnrampSuccessStep: FC<OnrampSuccessStepProps> = ({
   fillTxUrl,
   baseTransactionUrl,
   onOpenChange
-}) => {
+}: OnrampSuccessStepProps) {
   return (
-    <Flex
-      direction="column"
-      className="relay:w-full relay:h-full"
-    >
+    <Flex direction="column" className="relay:w-full relay:h-full">
       <Text style="h6" className="relay:mb-4">
         Transaction Details
       </Text>

--- a/packages/ui/src/components/widgets/PriceImpactTooltip.tsx
+++ b/packages/ui/src/components/widgets/PriceImpactTooltip.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { Anchor, Flex, Text } from '../primitives/index.js'
 import Tooltip from '../primitives/Tooltip.js'
 import type { ChildrenProps } from '../widgets/SwapWidgetRenderer.js'
@@ -14,11 +14,11 @@ const getFeeColor = (value: number | undefined) => {
   return value > 0 ? 'success' : undefined
 }
 
-export const PriceImpactTooltip: FC<PriceImpactTooltipProps> = ({
+export function PriceImpactTooltip({
   feeBreakdown,
   children,
   tooltipProps
-}) => {
+}: PriceImpactTooltipProps) {
   return (
     <Tooltip
       content={
@@ -41,9 +41,7 @@ export const PriceImpactTooltip: FC<PriceImpactTooltipProps> = ({
               ({feeBreakdown?.totalFees.priceImpactPercentage})
             </Text>
           </Flex>
-          <div
-            className="relay:w-full relay:h-px relay:bg-[var(--relay-colors-slate-6)] relay:my-2"
-          />
+          <div className="relay:w-full relay:h-px relay:bg-[var(--relay-colors-slate-6)] relay:my-2" />
           <Flex align="center" className="relay:w-full">
             <Text style="subtitle3" color="subtle" className="relay:mr-auto">
               Swap Impact
@@ -61,7 +59,11 @@ export const PriceImpactTooltip: FC<PriceImpactTooltipProps> = ({
             }
             return (
               <Flex key={fee.id} align="center" className="relay:w-full">
-                <Text style="subtitle3" color="subtle" className="relay:mr-auto">
+                <Text
+                  style="subtitle3"
+                  color="subtle"
+                  className="relay:mr-auto"
+                >
                   {fee.name}
                 </Text>
                 {feeBreakdown.isGasSponsored && fee.usd.value === 0 ? (

--- a/packages/ui/src/components/widgets/WidgetErrorWell.tsx
+++ b/packages/ui/src/components/widgets/WidgetErrorWell.tsx
@@ -1,6 +1,5 @@
 import { type Execute } from '@relayprotocol/relay-sdk'
 import { isDeadAddress, tronDeadAddress } from '@relayprotocol/relay-sdk'
-import { type FC } from 'react'
 import { Box, Flex, Text } from '../primitives/index.js'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle'
@@ -29,7 +28,7 @@ type Props = {
   toChainVmType?: string
 }
 
-export const WidgetErrorWell: FC<Props> = ({
+export function WidgetErrorWell({
   error,
   hasInsufficientBalance,
   quote,
@@ -44,7 +43,7 @@ export const WidgetErrorWell: FC<Props> = ({
   toChainWalletVMSupported,
   recipientLinkedWallet,
   toChainVmType
-}) => {
+}: Props) {
   const isSmallDevice = useMediaQuery('(max-width: 600px)')
   const fetchQuoteErrorMessage = error
     ? error?.response?.data?.message

--- a/packages/ui/src/constants/address.ts
+++ b/packages/ui/src/constants/address.ts
@@ -5,7 +5,7 @@ export const evmDeadAddress =
 export const solDeadAddress =
   'CbKGgVKLJFb8bBrf58DnAkdryX6ubewVytn7X957YwNr' as const
 
-export const getDeadAddress = (vmType?: ChainVM) => {
+export function getDeadAddress(vmType?: ChainVM) {
   if (vmType === 'svm') {
     return solDeadAddress
   } else {

--- a/packages/ui/src/hooks/useEnhancedTokensList.ts
+++ b/packages/ui/src/hooks/useEnhancedTokensList.ts
@@ -23,14 +23,14 @@ export type EnhancedToken = {
   chain?: RelayChain
 }
 
-export const useEnhancedTokensList = (
+export function useEnhancedTokensList(
   tokenLists: Currency[] | undefined,
   balanceMap: BalanceMap | undefined,
   context: 'from' | 'to',
   multiWalletSupportEnabled: boolean,
   chainId?: number,
   sortByBalance: boolean = true
-): EnhancedToken[] => {
+): EnhancedToken[] {
   const { chains } = useInternalRelayChains()
 
   const chainCurrencyMap = useMemo(() => {

--- a/packages/ui/src/hooks/useHyperliquidAccountMode.ts
+++ b/packages/ui/src/hooks/useHyperliquidAccountMode.ts
@@ -11,8 +11,9 @@ export type HyperliquidAccountMode =
   | 'default'
   | 'dexAbstraction'
 
-export const isUnifiedMode = (mode?: HyperliquidAccountMode) =>
-  mode === 'unifiedAccount' || mode === 'portfolioMargin'
+export function isUnifiedMode(mode?: HyperliquidAccountMode) {
+  return mode === 'unifiedAccount' || mode === 'portfolioMargin'
+}
 
 const useHyperliquidAccountMode = (address?: string, enabled = true) => {
   const isEvmAddress = isAddress(address ?? '')

--- a/packages/ui/src/hooks/useInternalRelayChains.ts
+++ b/packages/ui/src/hooks/useInternalRelayChains.ts
@@ -10,7 +10,7 @@ const DEFAULT_CACHE_OPTIONS = {
   refetchOnWindowFocus: false
 } as const
 
-export const useInternalRelayChains = (): ReturnType<typeof useRelayChains> => {
+export function useInternalRelayChains(): ReturnType<typeof useRelayChains> {
   const relayClient = useRelayClient()
   const providerOptions = useContext(ProviderOptionsContext)
 

--- a/packages/ui/src/hooks/useMultiWalletBalances.ts
+++ b/packages/ui/src/hooks/useMultiWalletBalances.ts
@@ -11,11 +11,11 @@ import type { LinkedWallet } from '../types/index.js'
 /**
  * Fetches and merges balances for linked wallets
  */
-export const useMultiWalletBalances = (
+export function useMultiWalletBalances(
   linkedWallets?: LinkedWallet[],
   primaryAddress?: string,
   evmChainIds: 'mainnet' | 'testnet' = 'mainnet'
-) => {
+) {
   const walletAddresses = useMemo(() => {
     const addresses = new Set<string>()
 

--- a/packages/ui/src/hooks/widget/useSwapButtonCta.ts
+++ b/packages/ui/src/hooks/widget/useSwapButtonCta.ts
@@ -27,7 +27,7 @@ export type UseSwapButtonCtaParams = {
  * @param params - Configuration object containing swap state
  * @returns The appropriate button CTA text
  */
-export const useSwapButtonCta = ({
+export function useSwapButtonCta({
   fromToken,
   toToken,
   multiWalletSupportEnabled,
@@ -44,7 +44,7 @@ export const useSwapButtonCta = ({
   isInsufficientLiquidityError,
   quote,
   operation
-}: UseSwapButtonCtaParams): string => {
+}: UseSwapButtonCtaParams): string {
   const firstStep = quote?.steps?.[0]
   const firstStepItem = firstStep?.items?.[0]
 

--- a/packages/ui/src/icons/ArrowLeftToLine.tsx
+++ b/packages/ui/src/icons/ArrowLeftToLine.tsx
@@ -6,12 +6,12 @@ type ArrowLeftToLineProps = React.SVGProps<SVGSVGElement> & {
   fill?: string
 }
 
-export const ArrowLeftToLine = ({
+export function ArrowLeftToLine({
   width = 15,
   height = 13,
   fill = '#889096',
   ...props
-}: ArrowLeftToLineProps) => {
+}: ArrowLeftToLineProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/ArrowRightFromLine.tsx
+++ b/packages/ui/src/icons/ArrowRightFromLine.tsx
@@ -6,12 +6,12 @@ type ArrowRightFromLineProps = React.SVGProps<SVGSVGElement> & {
   fill?: string
 }
 
-export const ArrowRightFromLine = ({
+export function ArrowRightFromLine({
   width = 15,
   height = 13,
   fill = '#5A45DF',
   ...props
-}: ArrowRightFromLineProps) => {
+}: ArrowRightFromLineProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/FileSignature.tsx
+++ b/packages/ui/src/icons/FileSignature.tsx
@@ -6,12 +6,12 @@ type FileSignatureProps = React.SVGProps<SVGSVGElement> & {
   fill?: string
 }
 
-export const FileSignature = ({
+export function FileSignature({
   width = 19,
   height = 16,
   fill = '#5A45DF',
   ...props
-}: FileSignatureProps) => {
+}: FileSignatureProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/RelayIcon.tsx
+++ b/packages/ui/src/icons/RelayIcon.tsx
@@ -6,12 +6,12 @@ type RelayIconProps = React.SVGProps<SVGSVGElement> & {
   fill?: string
 }
 
-export const RelayIcon = ({
+export function RelayIcon({
   width = 41,
   height = 40,
   fill = 'none',
   ...props
-}: RelayIconProps) => {
+}: RelayIconProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/Shuffle.tsx
+++ b/packages/ui/src/icons/Shuffle.tsx
@@ -6,12 +6,12 @@ type ShuffleProps = React.SVGProps<SVGSVGElement> & {
   fill?: string
 }
 
-export const Shuffle = ({
+export function Shuffle({
   width = 17,
   height = 15,
   fill = '#889096',
   ...props
-}: ShuffleProps) => {
+}: ShuffleProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/SwitchIcon.tsx
+++ b/packages/ui/src/icons/SwitchIcon.tsx
@@ -6,12 +6,12 @@ type SwitchIconProps = React.HTMLAttributes<SVGElement> & {
   fill?: string
 }
 
-export const SwitchIcon = ({
+export function SwitchIcon({
   width = 10,
   height = 10,
   fill = 'currentColor',
   ...props
-}: SwitchIconProps) => {
+}: SwitchIconProps) {
   return (
     <svg
       width={width}

--- a/packages/ui/src/icons/XIcon.tsx
+++ b/packages/ui/src/icons/XIcon.tsx
@@ -6,12 +6,12 @@ type XIconProps = React.HTMLAttributes<SVGElement> & {
   fill?: string
 }
 
-export const XIcon = ({
+export function XIcon({
   width = 10,
   height = 10,
   fill = 'currentColor',
   ...props
-}: XIconProps) => {
+}: XIconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/img/AllChainsLogo.tsx
+++ b/packages/ui/src/img/AllChainsLogo.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const AllChainsLogo = (props: React.HTMLAttributes<SVGElement>) => {
+export function AllChainsLogo(props: React.HTMLAttributes<SVGElement>) {
   return (
     <svg
       width="269"

--- a/packages/ui/src/img/MoonPayLogo.tsx
+++ b/packages/ui/src/img/MoonPayLogo.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const MoonPayLogo = (props: React.HTMLAttributes<SVGElement>) => {
+export function MoonPayLogo(props: React.HTMLAttributes<SVGElement>) {
   return (
     <svg
       width="160"

--- a/packages/ui/src/img/ReservoirText.tsx
+++ b/packages/ui/src/img/ReservoirText.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const ReservoirText = (props: React.HTMLAttributes<SVGElement>) => {
+export function ReservoirText(props: React.HTMLAttributes<SVGElement>) {
   return (
     <svg
       width="auto"

--- a/packages/ui/src/utils/address.ts
+++ b/packages/ui/src/utils/address.ts
@@ -17,10 +17,10 @@ import { isTronAddress } from './tron.js'
 import { isTonAddress } from './ton.js'
 import { isLighterAddress } from './lighter.js'
 
-export const isWalletVmTypeCompatible = (
+export function isWalletVmTypeCompatible(
   walletVmType?: ChainVM,
   chainVmType?: ChainVM
-) => {
+) {
   if (!walletVmType || !chainVmType) {
     return false
   }
@@ -33,10 +33,10 @@ export const isWalletVmTypeCompatible = (
   return chainVmType === 'hypevm' && walletVmType === 'evm'
 }
 
-export const isChainVmTypeSupported = (
+export function isChainVmTypeSupported(
   chainVmType: ChainVM | undefined,
   supportedWalletVMs: Omit<ChainVM, 'hypevm' | 'lvm'>[]
-) => {
+) {
   if (!chainVmType) {
     return true
   }
@@ -50,13 +50,13 @@ export const isChainVmTypeSupported = (
   )
 }
 
-export const isValidAddress = (
+export function isValidAddress(
   vmType?: ChainVM,
   address?: string,
   chainId?: number,
   connector?: string,
   connectorKeyOverrides?: RelayKitProviderProps['options']['vmConnectorKeyOverrides']
-) => {
+) {
   let eclipseConnectorKeys: string[] | undefined = undefined
   if (connectorKeyOverrides && connectorKeyOverrides[eclipse.id]) {
     eclipseConnectorKeys = connectorKeyOverrides[eclipse.id]
@@ -97,13 +97,13 @@ export const isValidAddress = (
   return false
 }
 
-export const addressWithFallback = (
+export function addressWithFallback(
   vmType?: ChainVM,
   address?: string,
   chainId?: number,
   connector?: string,
   connectorKeyOverrides?: Parameters<typeof isValidAddress>['4']
-) => {
+) {
   return address &&
     isValidAddress(
       vmType ?? 'evm',

--- a/packages/ui/src/utils/browser.ts
+++ b/packages/ui/src/utils/browser.ts
@@ -1,4 +1,7 @@
-export const isSafariBrowser = () =>
-  typeof window !== 'undefined' &&
-  navigator.userAgent.indexOf('Safari') > -1 &&
-  navigator.userAgent.indexOf('Chrome') <= -1
+export function isSafariBrowser() {
+  return (
+    typeof window !== 'undefined' &&
+    navigator.userAgent.indexOf('Safari') > -1 &&
+    navigator.userAgent.indexOf('Chrome') <= -1
+  )
+}

--- a/packages/ui/src/utils/errors.ts
+++ b/packages/ui/src/utils/errors.ts
@@ -1,4 +1,4 @@
-export const errorToJSON = (error: any) => {
+export function errorToJSON(error: any) {
   if (!(error instanceof Error)) {
     return error
   }
@@ -16,7 +16,7 @@ export const errorToJSON = (error: any) => {
   }
 }
 
-export const JSONToError = <T>(json?: T): Error | T | undefined => {
+export function JSONToError<T>(json?: T): Error | T | undefined {
   if (!json || typeof json !== 'string') {
     return json
   }

--- a/packages/ui/src/utils/fetcher.ts
+++ b/packages/ui/src/utils/fetcher.ts
@@ -13,7 +13,7 @@ const fetcher = async (url: string, headers?: HeadersInit) => {
 
 export default fetcher
 
-export const axiosPostFetcher = async (url: string, params: any) => {
+export async function axiosPostFetcher(url: string, params: any) {
   const { data } = await axios.post(url, params)
   return data
 }

--- a/packages/ui/src/utils/getTxBlockExplorerUrl.ts
+++ b/packages/ui/src/utils/getTxBlockExplorerUrl.ts
@@ -12,11 +12,11 @@ const appendQueryParams = (
   return url
 }
 
-export const getTxBlockExplorerUrl = (
+export function getTxBlockExplorerUrl(
   chainId?: number,
   chains?: RelayChain[],
   txHash?: string
-) => {
+) {
   const chain = chains?.find((chain) => chain.id === chainId)
   let blockExplorerUrl = getChainBlockExplorerUrl(chainId, chains)
 

--- a/packages/ui/src/utils/localStorage.ts
+++ b/packages/ui/src/utils/localStorage.ts
@@ -115,7 +115,7 @@ export function setCacheEntry(
   setRelayUiKitData({ genericCache: newCache })
 }
 
-export const alreadyAcceptedToken = (token: Token) => {
+export function alreadyAcceptedToken(token: Token) {
   const tokenKey = `${token.chainId}:${token.address}`
   const relayUiKitData = getRelayUiKitData()
   // Ensure acceptedUnverifiedTokens exists before accessing includes

--- a/packages/ui/src/utils/moonPay.ts
+++ b/packages/ui/src/utils/moonPay.ts
@@ -6,9 +6,9 @@ import defaultMoonPayCurrencies from '../constants/moonPayCurrencies.js'
 import { bitcoin } from './bitcoin.js'
 import { solana } from './solana.js'
 
-export const convertSupportedCurrencies = (
+export function convertSupportedCurrencies(
   currencies?: [MoonPayCryptoCurrency | MoonPayFiatCurrency] | null
-) => {
+) {
   if (currencies) {
     return currencies
       .filter(

--- a/packages/ui/src/utils/nativeMaxAmount.ts
+++ b/packages/ui/src/utils/nativeMaxAmount.ts
@@ -26,11 +26,11 @@ const fetchPromises: Record<string, Promise<bigint>> = {}
  * @param gasLimit - Optional: The gas limit to use for estimation (defaults to 400000n).
  * @returns The calculated gas buffer amount as a bigint, or 0n if estimation fails or balance is zero.
  */
-export const calculateEvmNativeGasBuffer = async (
+export async function calculateEvmNativeGasBuffer(
   publicClient: PublicClient,
   balance: bigint,
   gasLimit: bigint = 400000n
-): Promise<bigint> => {
+): Promise<bigint> {
   if (!balance || balance <= 0n) {
     return 0n
   }
@@ -88,9 +88,9 @@ export const calculateEvmNativeGasBuffer = async (
  * @param chainId - The chain ID of the SVM or Eclipse network.
  * @returns The calculated fee buffer amount (in lamports for Solana, Wei for Eclipse) as a bigint, or a fallback buffer if estimation fails.
  */
-export const calculateSvmNativeFeeBuffer = async (
+export async function calculateSvmNativeFeeBuffer(
   chainId: number
-): Promise<bigint> => {
+): Promise<bigint> {
   const isEclipseChain = chainId === 9286185
   const multiplier = isEclipseChain
     ? ECLIPSE_FEE_BUFFER_MULTIPLIER
@@ -155,12 +155,12 @@ export const calculateSvmNativeFeeBuffer = async (
  * @param publicClient - VIEM PublicClient (required for EVM calculation).
  * @returns A promise that resolves to the fee buffer amount as a bigint.
  */
-export const getFeeBufferAmount = async (
+export async function getFeeBufferAmount(
   vmType: ChainVM | undefined | null,
   chainId: number | undefined | null,
   balance: bigint,
   publicClient: PublicClient | null
-): Promise<bigint> => {
+): Promise<bigint> {
   const cacheKey = `${vmType}FeeBuffer:${chainId}`
   const cachedBufferStr = getCacheEntry(cacheKey)
 

--- a/packages/ui/src/utils/qrcode.ts
+++ b/packages/ui/src/utils/qrcode.ts
@@ -1,13 +1,13 @@
 import type { ChainVM } from '@relayprotocol/relay-sdk'
 import { solana } from './solana.js'
 
-export const generateQrWalletDeeplink = (
+export function generateQrWalletDeeplink(
   vm?: ChainVM,
   amount: string = '0',
   tokenAddress?: string,
   toAddress?: string,
   chainId?: number
-) => {
+) {
   if (vm === 'evm') {
     return `ethereum:${toAddress}@${chainId}?value=${tokenAddress ? 0 : amount}`
   } else if (vm === 'svm') {

--- a/packages/ui/src/utils/quote.ts
+++ b/packages/ui/src/utils/quote.ts
@@ -28,11 +28,11 @@ const formatUsdFee = (
   }
 }
 
-export const parseFees = (
+export function parseFees(
   selectedTo: RelayChain,
   selectedFrom: RelayChain,
   quote?: ReturnType<typeof useQuote>['data']
-): FeeBreakdown => {
+): FeeBreakdown {
   const fees = quote?.fees
   const expandedPriceImpact = quote?.details?.expandedPriceImpact
 
@@ -145,7 +145,7 @@ export const parseFees = (
   }
 }
 
-export const calculateRelayerFeeProportionUsd = (quote?: QuoteResponse) => {
+export function calculateRelayerFeeProportionUsd(quote?: QuoteResponse) {
   const usdIn = quote?.details?.currencyIn?.amountUsd
     ? Number(quote.details.currencyIn.amountUsd)
     : null
@@ -160,10 +160,10 @@ export const calculateRelayerFeeProportionUsd = (quote?: QuoteResponse) => {
   return BigInt(Math.floor((relayerServiceFeeUsd * 100) / usdIn))
 }
 
-export const calculateRelayerFeeProportion = (
+export function calculateRelayerFeeProportion(
   totalAmount: { rawExcludingOriginGas: bigint },
   feeBreakdown: BridgeFee[]
-) => {
+) {
   if (totalAmount.rawExcludingOriginGas > 0n) {
     const relayerFeeRaw =
       feeBreakdown.find((fee) => fee.id === 'relayer-fee')?.raw ?? 0n
@@ -172,7 +172,7 @@ export const calculateRelayerFeeProportion = (
   return 0n
 }
 
-export const isHighRelayerServiceFeeUsd = (quote?: QuoteResponse) => {
+export function isHighRelayerServiceFeeUsd(quote?: QuoteResponse) {
   const usdIn = quote?.details?.currencyIn?.amountUsd
     ? Number(quote.details.currencyIn.amountUsd)
     : null
@@ -192,20 +192,18 @@ export const isHighRelayerServiceFeeUsd = (quote?: QuoteResponse) => {
   )
 }
 
-export const extractQuoteId = (
+export function extractQuoteId(
   steps?: Execute['steps'] | QuoteResponse['steps']
-) => {
+) {
   return steps && steps[0] ? steps[0].requestId : undefined
 }
 
-export const extractDepositAddress = (steps?: Execute['steps']) => {
+export function extractDepositAddress(steps?: Execute['steps']) {
   const depositStep = steps?.find((step) => step.id === 'deposit')
   return depositStep?.depositAddress
 }
 
-export const calculatePriceTimeEstimate = (
-  details?: QuoteResponse['details']
-) => {
+export function calculatePriceTimeEstimate(details?: QuoteResponse['details']) {
   const isBitcoin =
     details?.currencyIn?.currency?.chainId === bitcoin.id ||
     details?.currencyOut?.currency?.chainId === bitcoin.id
@@ -220,12 +218,12 @@ export const calculatePriceTimeEstimate = (
   }
 }
 
-export const appendMetadataToRequest = (
+export function appendMetadataToRequest(
   baseUrl?: string,
   requestId?: string,
   additionalMetadata?: paths['/requests/metadata']['post']['requestBody']['content']['application/json']['additionalMetadata'],
   referrer?: string
-) => {
+) {
   if (requestId && additionalMetadata) {
     const triggerData: paths['/requests/metadata']['post']['requestBody']['content']['application/json'] & {
       referrer?: string
@@ -243,12 +241,10 @@ export const appendMetadataToRequest = (
   }
 }
 
-export const getCurrentStep = (
-  steps?: Execute['steps'] | null
-): {
+export function getCurrentStep(steps?: Execute['steps'] | null): {
   step: ExecuteStep | null | undefined
   stepItem: ExecuteStepItem | null | undefined
-} => {
+} {
   if (!steps) {
     return { step: null, stepItem: null }
   }
@@ -264,13 +260,13 @@ export const getCurrentStep = (
   return { step, stepItem }
 }
 
-export const getSwapEventData = (
+export function getSwapEventData(
   details: Execute['details'],
   fees: Execute['fees'],
   steps: Execute['steps'] | null,
   connector?: string,
   quoteParameters?: Parameters<typeof useQuote>['2']
-) => {
+) {
   let operation: string | undefined = details?.operation
 
   if (operation === 'swap') {
@@ -350,10 +346,10 @@ export const getSwapEventData = (
   }
 }
 
-export const calculateUsdValue = (
+export function calculateUsdValue(
   price?: number,
   amountString?: string
-): number | undefined => {
+): number | undefined {
   if (price && price > 0 && amountString && Number(amountString) > 0) {
     try {
       return parseFloat(amountString) * price
@@ -368,7 +364,7 @@ export const calculateUsdValue = (
   return undefined
 }
 
-export const isGasSponsored = (quote?: QuoteResponse) => {
+export function isGasSponsored(quote?: QuoteResponse) {
   return (
     quote?.fees?.subsidized?.amount != undefined &&
     quote?.fees?.subsidized?.amount != '0'

--- a/packages/ui/src/utils/relayTransaction.ts
+++ b/packages/ui/src/utils/relayTransaction.ts
@@ -2,23 +2,23 @@ import { type Execute, RelayClient } from '@relayprotocol/relay-sdk'
 import { type RelayTransaction } from '../types/index.js'
 import { formatSeconds } from './time.js'
 
-export const extractFromChain = (
+export function extractFromChain(
   transaction?: RelayTransaction | null,
   client?: RelayClient | null
-) => {
+) {
   const chainId = transaction?.data?.inTxs?.[0]?.chainId
   return client?.chains.find((chain) => chain.id === chainId)
 }
 
-export const extractToChain = (
+export function extractToChain(
   transaction?: RelayTransaction | null,
   client?: RelayClient | null
-) => {
+) {
   const chainId = transaction?.data?.outTxs?.[0]?.chainId
   return client?.chains.find((chain) => chain.id === chainId)
 }
 
-export const calculateFillTime = (transaction?: RelayTransaction | null) => {
+export function calculateFillTime(transaction?: RelayTransaction | null) {
   let fillTime = '-'
   let seconds = 0
   if (transaction?.status !== 'pending' && transaction?.status !== 'waiting') {
@@ -51,7 +51,7 @@ export const calculateFillTime = (transaction?: RelayTransaction | null) => {
   return { fillTime, seconds }
 }
 
-export const extractDepositRequestId = (steps?: Execute['steps'] | null) => {
+export function extractDepositRequestId(steps?: Execute['steps'] | null) {
   if (!steps?.length) return null
 
   // Find the first step that has a requestId

--- a/packages/ui/src/utils/slippage.ts
+++ b/packages/ui/src/utils/slippage.ts
@@ -8,7 +8,7 @@ export const ratingToColor = {
   low: undefined
 } as const
 
-export const getSlippageRating = (slippage: string): SlippageRating => {
+export function getSlippageRating(slippage: string): SlippageRating {
   const slippageNumber = parseFloat(slippage)
   if (slippageNumber >= 40) return 'very-high'
   if (slippageNumber >= 6) return 'high'

--- a/packages/ui/src/utils/steps.ts
+++ b/packages/ui/src/utils/steps.ts
@@ -150,7 +150,7 @@ type FormatTransactionStepsProps = {
  * - Showing clear action text with dynamic sub-text status updates
  * - Preserving transaction hash display and state management
  */
-export const formatTransactionSteps = ({
+export function formatTransactionSteps({
   steps,
   fromToken,
   toToken,
@@ -160,7 +160,7 @@ export const formatTransactionSteps = ({
   quote,
   currentAddress,
   linkedWallets
-}: FormatTransactionStepsProps) => {
+}: FormatTransactionStepsProps) {
   if (!steps || steps.length === 0) return { formattedSteps: [] }
 
   // Get wallet display name for customizing action text

--- a/packages/ui/src/utils/theme.ts
+++ b/packages/ui/src/utils/theme.ts
@@ -20,7 +20,13 @@ const TOKEN_REF_PATTERN =
 const RAW_CSS_PATTERN =
   /^(#|rgb|hsl|oklch|lch|lab|hwb|color\(|var\()|(\d+(\.\d+)?(px|rem|em|%|vh|vw|ch|ex|cap|ic|lh|rlh|vi|vb|vmin|vmax|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|deg|grad|rad|turn|s|ms))/i
 
-const NAMED_COLORS = new Set(['white', 'black', 'transparent', 'currentColor', 'inherit'])
+const NAMED_COLORS = new Set([
+  'white',
+  'black',
+  'transparent',
+  'currentColor',
+  'inherit'
+])
 
 function resolveThemeValue(value: string): string {
   if (NAMED_COLORS.has(value)) return value
@@ -31,10 +37,10 @@ function resolveThemeValue(value: string): string {
 }
 
 // Generate CSS variables based on theme and overrides
-export const generateCssVars = (
+export function generateCssVars(
   theme?: RelayKitTheme,
   themeOverrides?: ThemeOverridesMap
-): string => {
+): string {
   let cssString = ''
   if (!theme || !themeOverrides) {
     return cssString

--- a/packages/ui/src/utils/time.ts
+++ b/packages/ui/src/utils/time.ts
@@ -3,17 +3,17 @@ import time from 'dayjs/plugin/relativeTime.js'
 
 dayjs.extend(time)
 
-export const relativeTime = (
+export function relativeTime(
   timeString?: string | number,
   from?: string | number,
   withoutSuffix?: boolean
-): string => {
+): string {
   return from
     ? `${dayjs(timeString).from(from, withoutSuffix)}`
     : `${dayjs(timeString).fromNow(withoutSuffix)}`
 }
 
-export const formatSeconds = (seconds: number): string => {
+export function formatSeconds(seconds: number): string {
   seconds = Number(seconds)
   const d = Math.floor(seconds / (3600 * 24))
   const h = Math.floor((seconds % (3600 * 24)) / 3600)
@@ -29,7 +29,7 @@ export const formatSeconds = (seconds: number): string => {
   return parts.join(' ')
 }
 
-export const get15MinuteInterval = () => {
+export function get15MinuteInterval() {
   const now = new Date()
   const minutes = now.getUTCMinutes()
   const interval = Math.floor(minutes / 15)

--- a/packages/ui/src/utils/tokenSelector.ts
+++ b/packages/ui/src/utils/tokenSelector.ts
@@ -2,12 +2,12 @@ import type { RelayChain } from '@relayprotocol/relay-sdk'
 import type { Token } from '../types/index.js'
 import { getStarredChainIds, setRelayUiKitData } from './localStorage.js'
 
-export const isChainLocked = (
+export function isChainLocked(
   chainId: number | undefined,
   lockChainId: number | undefined,
   otherTokenChainId: number | undefined,
   lockToken: boolean
-) => {
+) {
   if (lockToken) {
     return true
   }
@@ -31,11 +31,11 @@ type GroupedChains = {
   alphabeticalChains: RelayChain[]
 }
 
-export const groupChains = (
+export function groupChains(
   chains: ChainOption[],
   popularChainIds?: number[],
   currentStarredChainIds?: number[] | undefined
-): GroupedChains => {
+): GroupedChains {
   // Get starred chains from localStorage or use provided ones
   let starredChainIds = currentStarredChainIds ?? getStarredChainIds()
 
@@ -90,7 +90,7 @@ export const groupChains = (
   }
 }
 
-export const sortChains = (chains: RelayChain[]) => {
+export function sortChains(chains: RelayChain[]) {
   return chains.sort((a, b) => {
     // First sort by priority chains
     const aIsPriority = POPULAR_CHAIN_IDS.has(a.id)
@@ -109,13 +109,13 @@ export const sortChains = (chains: RelayChain[]) => {
   })
 }
 
-export const getInitialChainFilter = (
+export function getInitialChainFilter(
   chainFilterOptions: RelayChain[],
   context: 'from' | 'to',
   depositAddressOnly: boolean,
   token?: Token,
   alwaysShowAllChains?: boolean
-) => {
+) {
   const defaultFilter = { id: undefined, name: 'All Chains' }
 
   // If there is only one chain, return it

--- a/packages/ui/src/utils/tokens.ts
+++ b/packages/ui/src/utils/tokens.ts
@@ -7,10 +7,10 @@ type ApiCurrency = NonNullable<
   paths['/chains']['get']['responses']['200']['content']['application/json']['chains']
 >[0]['currency']
 
-export const convertApiCurrencyToToken = (
+export function convertApiCurrencyToToken(
   currency: ApiCurrency | undefined | null,
   chainId: number
-): Token => {
+): Token {
   return {
     chainId: Number(chainId),
     address: currency?.address ?? '',
@@ -24,7 +24,7 @@ export const convertApiCurrencyToToken = (
   }
 }
 
-export const findBridgableToken = (chain?: RelayChain, token?: Token) => {
+export function findBridgableToken(chain?: RelayChain, token?: Token) {
   if (chain && token && token.chainId === chain.id) {
     const toCurrencies = [
       ...(chain?.erc20Currencies ?? []),
@@ -47,18 +47,20 @@ export const findBridgableToken = (chain?: RelayChain, token?: Token) => {
 /**
  * Generates a standard token image URL from symbol or metadata
  */
-export const generateTokenImageUrl = (token: { 
-  symbol?: string, 
-  metadata?: { logoURI?: string } 
-}): string => {
-  return token.metadata?.logoURI ||
+export function generateTokenImageUrl(token: {
+  symbol?: string
+  metadata?: { logoURI?: string }
+}): string {
+  return (
+    token.metadata?.logoURI ||
     `${ASSETS_RELAY_API}/icons/currencies/${token.symbol?.toLowerCase()}.png`
+  )
 }
 
 /**
  * Compares two tokens for equality based on chainId and address
  */
-export const tokensAreEqual = (a?: Token, b?: Token): boolean => {
+export function tokensAreEqual(a?: Token, b?: Token): boolean {
   if (!a && !b) return true
   if (!a || !b) return false
   return (
@@ -70,12 +72,16 @@ export const tokensAreEqual = (a?: Token, b?: Token): boolean => {
 /**
  * Normalizes token address for cross-chain consistency
  */
-export const normalizeTokenAddress = (chainId: number, address: string, vmType?: string): string => {
+export function normalizeTokenAddress(
+  chainId: number,
+  address: string,
+  vmType?: string
+): string {
   const normalizedAddress = vmType === 'evm' ? address.toLowerCase() : address
   return `${chainId}:${normalizedAddress}`
 }
 
-export const mergeTokenLists = (lists: (CurrencyList | undefined)[]) => {
+export function mergeTokenLists(lists: (CurrencyList | undefined)[]) {
   const mergedList: CurrencyList = []
   const seenTokens = new Set<string>()
 


### PR DESCRIPTION
## Summary

Converts every `export const foo = (...) => {...}` arrow function to an `export function foo(...) {...}` declaration across all packages (`sdk`, `ui`, `hooks`, and the wallet adapters).

**119 conversions across 87 files.**

## What changed

- `export const foo = (...) => {...}` → `export function foo(...) {...}`
- Async, generic (`<T,>` → `<T>`), and explicit-return-type variants handled
- Expression-body arrows wrapped in `return`
- Typed React components (`export const Foo: FC<Props> = ({...}) => {...}`) → `export function Foo({...}: Props) {...}`, with the now-unused `FC`/`FunctionComponent` import removed (kept where non-exported helpers in the same file still reference it)

## Left untouched

Non-exported arrow consts, `forwardRef`/`memo` components, object/value consts, and default exports.

## Behavior preservation

Arrow functions and function declarations differ in `this`/`arguments` binding, constructor usage, and `prototype`/`new.target`. Verified none of these apply:

- **`this`** — not referenced in any of the 87 changed files (word-boundary search)
- **`arguments`** — not referenced in any of the 87 changed files
- None of the converted functions are used as constructors (`new`), and `.prototype`/`new.target` are not referenced

Hoisting differs (TDZ vs hoisted) but is harmless for module-level exports. The conversion is therefore behavior-preserving.

## Verification

- 0 exported arrow consts remain
- SDK typecheck passes
- UI typecheck surfaces only 3 pre-existing errors (in untouched function bodies of `ErrorStep.tsx` / `DepositAddressModalRenderer.tsx`), not introduced by this refactor
- Prettier applied to all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)