### PR TITLE
Use current USD values from quote responses

### DIFF
--- a/packages/hooks/src/hooks/useQuote.ts
+++ b/packages/hooks/src/hooks/useQuote.ts
@@ -1,6 +1,7 @@
 import {
   MAINNET_RELAY_API,
   RelayClient,
+  normalizeQuoteUsdFields,
   type AdaptedWallet,
   type Execute,
   type paths,
@@ -44,10 +45,10 @@ export const queryQuote = function (
           method: 'post',
           data: options
         }
-        resolve({
+        resolve(normalizeQuoteUsdFields({
           ...response,
           request
-        })
+        }))
       })
       .catch((e) => {
         reject(e)

--- a/packages/sdk/src/actions/getQuote.test.ts
+++ b/packages/sdk/src/actions/getQuote.test.ts
@@ -142,4 +142,49 @@ describe('Should test the getQuote action.', () => {
       })
     )
   })
+
+  it('Should prefer amountUsdCurrent when quote responses provide it', async () => {
+    axiosRequestSpy.mockResolvedValueOnce({
+      data: {
+        details: {
+          currencyIn: {
+            amountUsd: '21.165148',
+            amountUsdCurrent: '23.500000'
+          },
+          currencyOut: {
+            amountUsd: '17.130605',
+            amountUsdCurrent: '20.900000'
+          }
+        },
+        fees: {
+          relayerService: {
+            amountUsd: '0.100000',
+            amountUsdCurrent: '0.250000'
+          }
+        }
+      },
+      status: 200
+    })
+
+    client = createClient({
+      baseApiUrl: MAINNET_RELAY_API,
+      chains: relayChains
+    })
+
+    const quote = await client.actions.getQuote(
+      {
+        toChainId: 1,
+        chainId: 8453,
+        currency: '0x0000000000000000000000000000000000000000',
+        toCurrency: '0x0000000000000000000000000000000000000000',
+        tradeType: 'EXACT_INPUT',
+        amount: '1000000000000000'
+      },
+      true
+    )
+
+    expect(quote.details.currencyIn?.amountUsd).toBe('23.500000')
+    expect(quote.details.currencyOut?.amountUsd).toBe('20.900000')
+    expect(quote.fees?.relayerService?.amountUsd).toBe('0.250000')
+  })
 })

--- a/packages/sdk/src/actions/getQuote.ts
+++ b/packages/sdk/src/actions/getQuote.ts
@@ -7,6 +7,7 @@ import {
   APIError,
   adaptViemWallet,
   getApiKeyHeader,
+  normalizeQuoteUsdFields,
   type SimulateContractRequest
 } from '../utils/index.js'
 import {
@@ -176,5 +177,5 @@ export async function getQuote(
   if (res.status !== 200) {
     throw new APIError(res?.data?.message, res.status, res.data)
   }
-  return { ...res.data, request } as Execute
+  return normalizeQuoteUsdFields({ ...res.data, request } as Execute)
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -17,6 +17,7 @@ export {
   isSimulateContractRequest
 } from './simulateContract.js'
 export { safeStructuredClone } from './structuredClone.js'
+export { normalizeQuoteUsdFields } from './normalizeQuoteUsd.js'
 export { repeatUntilOk } from './repeatUntilOk.js'
 export { prepareHyperliquidSteps } from './hyperliquid.js'
 export { isRelayApiUrl, getApiKeyHeader } from './apiKey.js'

--- a/packages/sdk/src/utils/normalizeQuoteUsd.ts
+++ b/packages/sdk/src/utils/normalizeQuoteUsd.ts
@@ -1,0 +1,35 @@
+import { safeStructuredClone } from './structuredClone.js'
+
+type QuoteUsdNode = {
+  amountUsd?: string
+  amountUsdCurrent?: string
+  [key: string]: unknown
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null
+}
+
+const normalizeNode = (value: unknown): void => {
+  if (Array.isArray(value)) {
+    value.forEach(normalizeNode)
+    return
+  }
+
+  if (!isObject(value)) {
+    return
+  }
+
+  const node = value as QuoteUsdNode
+  if (typeof node.amountUsdCurrent === 'string' && node.amountUsdCurrent.length) {
+    node.amountUsd = node.amountUsdCurrent
+  }
+
+  Object.values(node).forEach(normalizeNode)
+}
+
+export const normalizeQuoteUsdFields = <T>(quote: T): T => {
+  const normalized = safeStructuredClone(quote)
+  normalizeNode(normalized)
+  return normalized
+}


### PR DESCRIPTION
## Summary
- normalize quote payloads so `amountUsd` uses `amountUsdCurrent` when the API returns both
- apply that normalization in both the SDK `getQuote` path and the hooks quote query path
- add a regression test covering nested quote fields like `details.currencyIn`, `details.currencyOut`, and `fees.relayerService`

## Why
The `/quote/v2` responses discussed in #1007 can contain fresher USD values in `amountUsdCurrent` while the existing UI and SDK consumers still read `amountUsd`. That leaves swap impact and USD displays out of sync with the current quote payload even when the token amounts are otherwise correct.

## Testing
- added a failing regression test first in `packages/sdk/src/actions/getQuote.test.ts`
- `node node_modules/.pnpm/vitest@1.6.1_@types+node@22.13.4_@vitest+ui@1.6.1_lightningcss@1.31.1_terser@5.39.0/node_modules/vitest/vitest.mjs run packages/sdk/src/actions/getQuote.test.ts`
- `./node_modules/.pnpm/typescript@5.4.5/node_modules/typescript/bin/tsc -p packages/sdk/tsconfig.json --noEmit`
- `./node_modules/.pnpm/typescript@5.4.5/node_modules/typescript/bin/tsc -p packages/hooks/tsconfig.json --noEmit`

Closes #1007
