### PR TITLE
fix: embed sourcesContent in published sourcemaps

### DIFF
--- a/.changeset/spotty-maps-heal.md
+++ b/.changeset/spotty-maps-heal.md
@@ -1,0 +1,13 @@
+---
+'@relayprotocol/relay-sdk': patch
+'@relayprotocol/relay-kit-hooks': patch
+'@relayprotocol/relay-kit-ui': patch
+'@relayprotocol/relay-bitcoin-wallet-adapter': patch
+'@relayprotocol/relay-ethers-wallet-adapter': patch
+'@relayprotocol/relay-lighter-wallet-adapter': patch
+'@relayprotocol/relay-svm-wallet-adapter': patch
+'@relayprotocol/relay-ton-wallet-adapter': patch
+'@relayprotocol/relay-tron-wallet-adapter': patch
+---
+
+Embed sourcesContent in published sourcemaps so they resolve without the unpublished src directory

--- a/packages/hooks/tsconfig.build.json
+++ b/packages/hooks/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": ".",
   }
 }

--- a/packages/relay-bitcoin-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-bitcoin-wallet-adapter/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/relay-ethers-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-ethers-wallet-adapter/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/relay-lighter-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-lighter-wallet-adapter/tsconfig.build.json
@@ -9,6 +9,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/relay-svm-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-svm-wallet-adapter/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/relay-ton-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-ton-wallet-adapter/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/relay-tron-wallet-adapter/tsconfig.build.json
+++ b/packages/relay-tron-wallet-adapter/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": "."
   }
 }

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "rootDir": ".",
   }
 }


### PR DESCRIPTION
The published packages only ship build output (_cjs, _esm, _types), but the emitted sourcemaps reference the unpublished src directory and omit sourcesContent, so tools like Vite's dev server log a missing-source warning per module. Enabling inlineSources makes the maps self-contained.

Fixes #1058